### PR TITLE
Convert Dockerfile to use Distroless nonroot image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,21 @@
 FROM node:22-slim AS builder
 
+WORKDIR /app
+
 COPY . /app
 COPY tsconfig.json /tsconfig.json
 
-WORKDIR /app
-
 RUN --mount=type=cache,target=/root/.npm npm install
-
 RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
+RUN npm install @bitwarden/cli@2025.6.1
 
-FROM node:22-slim AS release
+FROM gcr.io/distroless/nodejs22-debian12:nonroot AS release
 
-COPY --from=builder /app/dist /app/dist
-COPY --from=builder /app/package.json /app/package.json
-COPY --from=builder /app/package-lock.json /app/package-lock.json
+WORKDIR /app
+USER nonroot
+
+COPY --from=builder /app/ /app/
 
 ENV NODE_ENV=production
 
-WORKDIR /app
-
-RUN npm ci --ignore-scripts --omit-dev
-
-RUN npm install @bitwarden/cli@2025.6.1
-
-ENTRYPOINT ["node", "dist/index.js"]
+CMD ["dist/index.js"]


### PR DESCRIPTION
## 📔 Objective

Convert the Dockerfile to using Google's Distroless node22 image. This reduces the number of vulnerabilites in the container image and reduces attack surface (and reduces file size). 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
