### PR TITLE
fix: Pass environment variables to child processes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -737,7 +737,10 @@ async function executeCliCommand(command: string): Promise<CliResponse> {
       } as const;
     }
 
-    const { stdout, stderr } = await execPromise(`bw ${sanitizedCommand}`);
+    // Pass environment variables to child process so BW_SESSION is available
+    const { stdout, stderr } = await execPromise(`bw ${sanitizedCommand}`, {
+      env: { ...process.env }
+    });
     const result: CliResponse = {};
     if (stdout) result.output = stdout;
     if (stderr) result.errorOutput = stderr;


### PR DESCRIPTION
## Description

This PR fixes issue #57 where the `BW_SESSION` environment variable was not being passed to child `bw` CLI processes, preventing authentication.

## Problem

The `executeCliCommand` function in `src/index.ts` executes `bw` commands without passing the parent process environment:

```javascript
const { stdout, stderr } = await execPromise(`bw ${sanitizedCommand}`);
```

This causes all commands to fail with "vault is locked" even when `BW_SESSION` is set correctly.

## Solution

Pass the environment variables to the child process:

```javascript
const { stdout, stderr } = await execPromise(`bw ${sanitizedCommand}`, {
  env: { ...process.env }
});
```

## Testing

1. Set up a valid session: `export BW_SESSION=$(bw unlock --raw)`
2. Run the MCP server with this fix
3. Verify commands now work correctly (status shows "unlocked", list items works, etc.)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have tested the fix
- [x] This change requires no documentation update

## Fixes

Fixes #57