### PR TITLE
Fixes for CLI commands

### DIFF
--- a/src/handlers/cli.ts
+++ b/src/handlers/cli.ts
@@ -123,7 +123,8 @@ export const handleCreate = withValidation(
     const { objectType, name, type, notes, login } = validatedArgs;
 
     if (objectType === 'folder') {
-      const encodedItem = JSON.stringify({ name });
+      const itemJson = JSON.stringify({ name });
+      const encodedItem = Buffer.from(itemJson).toString('base64');
       const command = buildSafeCommand('create', ['folder', encodedItem]);
       const response = await executeCliCommand(command);
       return toMcpFormat(response);
@@ -139,7 +140,8 @@ export const handleCreate = withValidation(
         item['login'] = login;
       }
 
-      const encodedItem = JSON.stringify(item);
+      const itemJson = JSON.stringify(item);
+      const encodedItem = Buffer.from(itemJson).toString('base64');
       const command = buildSafeCommand('create', ['item', encodedItem]);
       const response = await executeCliCommand(command);
       return toMcpFormat(response);
@@ -151,7 +153,8 @@ export const handleEdit = withValidation(editSchema, async (validatedArgs) => {
   const { objectType, id, name, notes, login } = validatedArgs;
 
   if (objectType === 'folder') {
-    const encodedItem = JSON.stringify({ name });
+    const itemJson = JSON.stringify({ name });
+    const encodedItem = Buffer.from(itemJson).toString('base64');
     const command = buildSafeCommand('edit', ['folder', id, encodedItem]);
     const response = await executeCliCommand(command);
     return toMcpFormat(response);
@@ -162,7 +165,8 @@ export const handleEdit = withValidation(editSchema, async (validatedArgs) => {
     if (notes) updates['notes'] = notes;
     if (login) updates['login'] = login;
 
-    const encodedUpdates = JSON.stringify(updates);
+    const updatesJson = JSON.stringify(updates);
+    const encodedUpdates = Buffer.from(updatesJson).toString('base64');
     const command = buildSafeCommand('edit', ['item', id, encodedUpdates]);
     const response = await executeCliCommand(command);
     return toMcpFormat(response);

--- a/src/handlers/cli.ts
+++ b/src/handlers/cli.ts
@@ -120,7 +120,7 @@ export const handleGenerate = withValidation(
 export const handleCreate = withValidation(
   createSchema,
   async (validatedArgs) => {
-    const { objectType, name, type, notes, login } = validatedArgs;
+    const { objectType, name, type, notes, login, folderId } = validatedArgs;
 
     if (objectType === 'folder') {
       const folder: BitwardenFolder = { name };
@@ -143,6 +143,10 @@ export const handleCreate = withValidation(
         item.notes = notes;
       }
 
+      if (folderId !== undefined) {
+        item.folderId = folderId;
+      }
+
       if (type === 1 && login) {
         // Only set defined login properties
         const loginData: BitwardenItem['login'] = {};
@@ -163,7 +167,7 @@ export const handleCreate = withValidation(
 );
 
 export const handleEdit = withValidation(editSchema, async (validatedArgs) => {
-  const { objectType, id, name, notes, login } = validatedArgs;
+  const { objectType, id, name, notes, login, folderId } = validatedArgs;
 
   if (objectType === 'folder') {
     // For folders, we still just update the name directly
@@ -191,6 +195,7 @@ export const handleEdit = withValidation(editSchema, async (validatedArgs) => {
       // Only update properties that were provided
       if (name !== undefined) existingItem.name = name;
       if (notes !== undefined) existingItem.notes = notes;
+      if (folderId !== undefined) existingItem.folderId = folderId;
       if (login !== undefined) {
         // Merge login properties with existing login data, maintaining type safety
         const currentLogin = existingItem.login || {};

--- a/src/schemas/cli.ts
+++ b/src/schemas/cli.ts
@@ -176,6 +176,10 @@ export const editLoginSchema = z.object({
   username: z.string().optional(),
   // New password for the login
   password: z.string().optional(),
+  // List of URIs associated with the login
+  uris: z.array(uriSchema).optional(),
+  // Time-based one-time password (TOTP) secret
+  totp: z.string().optional(),
 });
 
 // Schema for validating 'edit' command parameters

--- a/src/schemas/cli.ts
+++ b/src/schemas/cli.ts
@@ -4,19 +4,7 @@
  *
  * Features:
  * - Vault locking/unlocking operations
- * - Item listing, retrieva      // Login should only be provided for items, not folders
-      if (data.objectType === 'folder' && data.login) {
-        return false;
-      }
-      // FolderId should only be provided for items, not folders
-      if (data.objectType === 'folder' && data.folderId) {
-        return false;
-      }
-      return true;
-    },
-    {
-      message:
-        'Notes, login information, and folder assignment are only valid for items, not folders',nagement
+ * - Item listing, retrieval, and management
  * - Password generation and secure operations
  * - Folder and item creation/editing/deletion
  */

--- a/src/schemas/cli.ts
+++ b/src/schemas/cli.ts
@@ -4,7 +4,19 @@
  *
  * Features:
  * - Vault locking/unlocking operations
- * - Item listing, retrieval, and management
+ * - Item listing, retrieva      // Login should only be provided for items, not folders
+      if (data.objectType === 'folder' && data.login) {
+        return false;
+      }
+      // FolderId should only be provided for items, not folders
+      if (data.objectType === 'folder' && data.folderId) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        'Notes, login information, and folder assignment are only valid for items, not folders',nagement
  * - Password generation and secure operations
  * - Folder and item creation/editing/deletion
  */
@@ -141,6 +153,8 @@ export const createSchema = z
     notes: z.string().optional(),
     // Login details (required when type is 1)
     login: loginSchema.optional(),
+    // Folder ID to assign the item to (only for items)
+    folderId: z.string().optional(),
   })
   .refine(
     (data) => {
@@ -166,7 +180,7 @@ export const createSchema = z
     },
     {
       message:
-        'Item type is required for items, login details are required for login items, and notes/login are only valid for items',
+        'Item type is required for items, login details are required for login items, and notes/login/folderId are only valid for items',
     },
   );
 
@@ -195,6 +209,8 @@ export const editSchema = z
     notes: z.string().optional(),
     // Updated login information (only for items)
     login: editLoginSchema.optional(),
+    // New folder ID to assign the item to (only for items)
+    folderId: z.string().optional(),
   })
   .refine(
     (data) => {
@@ -206,11 +222,15 @@ export const editSchema = z
       if (data.objectType === 'folder' && data.login) {
         return false;
       }
+      // FolderId should only be provided for items, not folders
+      if (data.objectType === 'folder' && data.folderId) {
+        return false;
+      }
       return true;
     },
     {
       message:
-        'Notes and login information are only valid for items, not folders',
+        'Notes, login information, and folder assignment are only valid for items, not folders',
     },
   );
 

--- a/src/tools/cli.ts
+++ b/src/tools/cli.ts
@@ -210,6 +210,11 @@ export const createTool: Tool = {
           },
         },
       },
+      folderId: {
+        type: 'string',
+        description:
+          'Folder ID to assign the item to (only valid for items, not folders)',
+      },
     },
     required: ['objectType', 'name'],
   },
@@ -251,7 +256,36 @@ export const editTool: Tool = {
             type: 'string',
             description: 'New password for the login',
           },
+          uris: {
+            type: 'array',
+            description: 'List of URIs associated with the login',
+            items: {
+              type: 'object',
+              properties: {
+                uri: {
+                  type: 'string',
+                  description: 'URI for the login (e.g., https://example.com)',
+                },
+                match: {
+                  type: 'number',
+                  description:
+                    'URI match type (0: Domain, 1: Host, 2: Starts With, 3: Exact, 4: Regular Expression, 5: Never)',
+                  enum: [0, 1, 2, 3, 4, 5],
+                },
+              },
+              required: ['uri'],
+            },
+          },
+          totp: {
+            type: 'string',
+            description: 'TOTP secret for the login',
+          },
         },
+      },
+      folderId: {
+        type: 'string',
+        description:
+          'New folder ID to assign the item to (only valid for items, not folders)',
       },
     },
     required: ['objectType', 'id'],

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -24,6 +24,7 @@ export interface BitwardenItem {
   name?: string;
   notes?: string;
   type?: number;
+  folderId?: string;
   login?: {
     username?: string;
     password?: string;


### PR DESCRIPTION
## 📔 Objective

- Fixes create and update tools for items and folders. Base64 encoding was missing from input to the CLI commands.
- Added missing properties from create/update item objects
- Use property types for items and folders
- Added support for folder assignment on items
