### PR TITLE
Fix Cosign arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
           for tag in "${tags[@]}"; do
             images+="${tag}@${DIGEST} "
           done
-          cosign sign --yes "${images}"
+          cosign sign --yes "${images[@]}"
           echo "images=${images}" >> "$GITHUB_OUTPUT"
 
       - name: Verify the signed image with Cosign


### PR DESCRIPTION
## 🎟️ Tracking

Follow-up from #86

## 📔 Objective

The build job started failing after merging #86. After analyzing, it appears that the images with tags were being expanded together improperly. This should hopefully expand them separately as multiple arguments to the cosign utility.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
