### PR TITLE
restructure CLI item/folder create and edit tools

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,10 +170,11 @@ export const handleApiCommand = withValidation(
 
 - **Session**: lock, unlock, sync, status
 - **Retrieval**: list, get
-- **Modification**: create, edit, delete, restore
+- **Item Management**: create, edit, delete, restore
+- **Folder Management**: create, edit
 - **Utility**: generate
-- **Organization**: confirm (confirm invited members), list org-members, list org-collections, create org-collection, edit org-collection, edit item-collections, get org-collection, move (transfer items to organization)
-- **Device Approval**: device-approval list, device-approval approve, device-approval approve-all, device-approval deny, device-approval deny-all
+- **Organization**: list and confirm organization members, manage and move organization items
+- **Device Approval**: list, approve, and deny devices
 
 **Organization Administration (API-based):**
 
@@ -182,6 +183,7 @@ export const handleApiCommand = withValidation(
 - **Groups**: list, create, update, delete, manage group membership
 - **Policies**: list, retrieve, update organization policies
 - **Events**: retrieve organization audit logs and events
+- **Organization**: manage organization subscriptions
 
 ## Organization Administration Tools
 
@@ -211,41 +213,47 @@ This ensures that all organization management operations work correctly with Bit
 
 ### Collections Management
 
-- **list-collections**: Retrieve all organization collections with access permissions
-- **get-collection**: Get details of a specific collection by ID
-- **create-collection**: Create new collections for organizing vault items
-- **update-collection**: Modify collection properties and permissions
-- **delete-collection**: Remove collections from the organization
+- **list_org_collections**: Retrieve all organization collections with access permissions
+- **get_org_collection**: Get details of a specific collection by ID
+- **update_org_collection**: Modify collection properties and permissions
+- **delete_org_collection**: Remove collections from the organization
 
 ### Members Management
 
-- **list-members**: List all organization members with status and access details
-- **get-member**: Retrieve specific member information and permissions
-- **invite-member**: Send invitations to new users to join the organization
-- **update-member**: Modify member roles, access levels, and permissions
-- **remove-member**: Remove users from the organization
-- **reinvite-member**: Resend invitation emails to pending members
+- **list_org_members**: List all organization members with status and access details
+- **get_org_member**: Retrieve specific member information and permissions
+- **invite_org_member**: Send invitations to new users to join the organization
+- **update_org_member**: Modify member roles, access levels, and permissions
+- **remove_org_member**: Remove users from the organization
+- **reinvite_org_member**: Resend invitation emails to pending members
+- **get_org_member_groups**: Get member's group assignments
+- **update_org_member_groups**: Update member's group assignments
 
 ### Groups Management
 
-- **list-groups**: Retrieve all organization groups and their configurations
-- **get-group**: Get details of a specific group including member assignments
-- **create-group**: Create new groups for organizing members
-- **update-group**: Modify group properties and access permissions
-- **delete-group**: Remove groups from the organization
-- **get-group-members**: List all members assigned to a specific group
-- **update-group-members**: Add or remove members from groups
+- **list_org_groups**: Retrieve all organization groups and their configurations
+- **get_org_group**: Get details of a specific group including member assignments
+- **create_org_group**: Create new groups for organizing members
+- **update_org_group**: Modify group properties and access permissions
+- **delete_org_group**: Remove groups from the organization
+- **get_org_group_members**: List all members assigned to a specific group
+- **update_org_group_members**: Add or remove members from groups
 
 ### Policies Management
 
-- **list-policies**: Retrieve all organization policies and their current status
-- **get-policy**: Get details of a specific policy by type
-- **update-policy**: Enable, disable, or configure organization security policies
+- **list_org_policies**: Retrieve all organization policies and their current status
+- **get_org_policy**: Get details of a specific policy by type
+- **update_org_policy**: Enable, disable, or configure organization security policies
 
 ### Event Monitoring
 
-- **list-events**: Retrieve organization audit logs with filtering options
-- **get-events**: Get specific event details for compliance and security monitoring
+- **get_org_events**: Retrieve organization audit logs with filtering options
+
+### Organization Management
+
+- **get_org_subscription**: Get subscription details
+- **update_org_subscription**: Update subscription settings
+- **import_org_users_and_groups**: Import members and groups
 
 ### API Capabilities vs CLI Limitations
 
@@ -322,7 +330,9 @@ npm run lint     # ESLint + Prettier
 
 ### CLI Operations
 
-**Base64 Encoding (create/edit):**
+**Base64 Encoding:**
+
+Operations where JSON data needs to be passed in should always base64 encode the JSON object.
 
 ```typescript
 const itemBase64 = Buffer.from(JSON.stringify(item), 'utf8').toString('base64');

--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ The server provides comprehensive Bitwarden functionality through two authentica
 | `list`                  | List vault items/folders                                      | `type` (items/folders/collections/organizations/org-members/org-collections) |
 | `get`                   | Get specific item/folder                                      | `object`, `id`, optional `organizationid` for org-collection                 |
 | `generate`              | Generate password/passphrase                                  | Various optional parameters                                                  |
-| `create`                | Create new item or folder                                     | `objectType`, `name`, additional fields for items                            |
-| `edit`                  | Edit existing item or folder                                  | `objectType`, `id`, optional fields to update                                |
+| `create_item`           | Create new vault item (login)                                 | `name`, `login`, optional `notes`, `folderId`                                |
+| `create_folder`         | Create new folder                                             | `name`                                                                       |
+| `edit_item`             | Edit existing vault item                                      | `id`, optional `name`, `notes`, `login`, `folderId`                          |
+| `edit_folder`           | Edit existing folder                                          | `id`, `name`                                                                 |
 | `edit_item_collections` | Edit which collections an item belongs to                     | `itemId`, `organizationId`, `collectionIds` (array)                          |
 | `move`                  | Move (share) a vault item to an organization with collections | `itemId`, `organizationId`, `collectionIds` (array)                          |
 | `delete`                | Delete vault item/folder                                      | `object`, `id`, optional `permanent`                                         |

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,10 @@ import {
   handleList,
   handleGet,
   handleGenerate,
-  handleCreate,
-  handleEdit,
+  handleCreateItem,
+  handleCreateFolder,
+  handleEditItem,
+  handleEditFolder,
   handleDelete,
   handleConfirm,
   handleCreateOrgCollection,
@@ -116,10 +118,14 @@ async function runServer(): Promise<void> {
             return await handleGet(args);
           case 'generate':
             return await handleGenerate(args);
-          case 'create':
-            return await handleCreate(args);
-          case 'edit':
-            return await handleEdit(args);
+          case 'create_item':
+            return await handleCreateItem(args);
+          case 'create_folder':
+            return await handleCreateFolder(args);
+          case 'edit_item':
+            return await handleEditItem(args);
+          case 'edit_folder':
+            return await handleEditFolder(args);
           case 'delete':
             return await handleDelete(args);
           case 'confirm':
@@ -144,7 +150,7 @@ async function runServer(): Promise<void> {
             return await handleDeviceApprovalDenyAll(args);
           case 'restore':
             return await handleRestore(args);
-            
+
           // Organization API Tools - Collections
           case 'list_org_collections':
             return await handleListOrgCollections(args);

--- a/src/schemas/cli.ts
+++ b/src/schemas/cli.ts
@@ -163,56 +163,23 @@ export const loginSchema = z.object({
   totp: z.string().optional(),
 });
 
-// Schema for validating 'create' command parameters
-export const createSchema = z
-  .object({
-    // Name of the item/folder to create
-    name: z.string().min(1, 'Name is required'),
-    // Type of object to create: 'item' or 'folder'
-    objectType: z.enum(['item', 'folder']),
-    // Type of item to create (only for items)
-    type: z
-      .union([
-        z.literal(1), // Login
-        z.literal(2), // Secure Note
-        z.literal(3), // Card
-        z.literal(4), // Identity
-      ])
-      .optional(),
-    // Optional notes for the item
-    notes: z.string().optional(),
-    // Login details (required when type is 1)
-    login: loginSchema.optional(),
-    // Folder ID to assign the item to (only for items)
-    folderId: z.string().optional(),
-  })
-  .refine(
-    (data) => {
-      // If objectType is item, type should be provided
-      if (data.objectType === 'item') {
-        if (!data.type) {
-          return false;
-        }
-        // If type is login (1), login object should be provided
-        if (data.type === 1) {
-          return !!data.login; // login object should exist
-        }
-      }
-      // Notes should only be provided for items, not folders
-      if (data.objectType === 'folder' && data.notes) {
-        return false;
-      }
-      // Login should only be provided for items, not folders
-      if (data.objectType === 'folder' && data.login) {
-        return false;
-      }
-      return true;
-    },
-    {
-      message:
-        'Item type is required for items, login details are required for login items, and notes/login/folderId are only valid for items',
-    },
-  );
+// Schema for validating 'create item' command parameters
+export const createItemSchema = z.object({
+  // Name of the item to create
+  name: z.string().min(1, 'Name is required'),
+  // Optional notes for the item
+  notes: z.string().optional(),
+  // Login details (required for login items)
+  login: loginSchema,
+  // Folder ID to assign the item to
+  folderId: z.string().optional(),
+});
+
+// Schema for validating 'create folder' command parameters
+export const createFolderSchema = z.object({
+  // Name of the folder to create
+  name: z.string().min(1, 'Name is required'),
+});
 
 // Schema for validating login fields during item editing
 export const editLoginSchema = z.object({
@@ -226,43 +193,27 @@ export const editLoginSchema = z.object({
   totp: z.string().optional(),
 });
 
-// Schema for validating 'edit' command parameters
-export const editSchema = z
-  .object({
-    // Type of object to edit: 'item' or 'folder'
-    objectType: z.enum(['item', 'folder']),
-    // ID of the item/folder to edit
-    id: z.string().min(1, 'ID is required'),
-    // New name for the item/folder
-    name: z.string().optional(),
-    // New notes for the item
-    notes: z.string().optional(),
-    // Updated login information (only for items)
-    login: editLoginSchema.optional(),
-    // New folder ID to assign the item to (only for items)
-    folderId: z.string().optional(),
-  })
-  .refine(
-    (data) => {
-      // Notes should only be provided for items, not folders
-      if (data.objectType === 'folder' && data.notes) {
-        return false;
-      }
-      // Login should only be provided for items, not folders
-      if (data.objectType === 'folder' && data.login) {
-        return false;
-      }
-      // FolderId should only be provided for items, not folders
-      if (data.objectType === 'folder' && data.folderId) {
-        return false;
-      }
-      return true;
-    },
-    {
-      message:
-        'Notes, login information, and folder assignment are only valid for items, not folders',
-    },
-  );
+// Schema for validating 'edit item' command parameters (login)
+export const editItemSchema = z.object({
+  // ID of the item to edit
+  id: z.string().min(1, 'ID is required'),
+  // New name for the item
+  name: z.string().optional(),
+  // New notes for the item
+  notes: z.string().optional(),
+  // Updated login information
+  login: editLoginSchema.optional(),
+  // New folder ID to assign the item to
+  folderId: z.string().optional(),
+});
+
+// Schema for validating 'edit folder' command parameters
+export const editFolderSchema = z.object({
+  // ID of the folder to edit
+  id: z.string().min(1, 'ID is required'),
+  // New name for the folder
+  name: z.string().min(1, 'Name is required'),
+});
 
 // Schema for validating 'delete' command parameters
 export const deleteSchema = z.object({

--- a/src/tools/cli.ts
+++ b/src/tools/cli.ts
@@ -164,34 +164,24 @@ export const generateTool: Tool = {
   },
 };
 
-export const createTool: Tool = {
-  name: 'create',
-  description: 'Create a new item or folder in your vault',
+export const createItemTool: Tool = {
+  name: 'create_item',
+  description:
+    'Create a new item (login, secure note, card, or identity) in your vault',
   inputSchema: {
     type: 'object',
     properties: {
-      objectType: {
-        type: 'string',
-        description: 'Type of object to create',
-        enum: ['item', 'folder'],
-      },
       name: {
         type: 'string',
-        description: 'Name of the item or folder',
-      },
-      type: {
-        type: 'number',
-        description:
-          'Type of item (1: Login, 2: Secure Note, 3: Card, 4: Identity) - required for items',
-        enum: [1, 2, 3, 4],
+        description: 'Name of the item',
       },
       notes: {
         type: 'string',
-        description: 'Notes for the item (only valid for items, not folders)',
+        description: 'Notes for the item',
       },
       login: {
         type: 'object',
-        description: 'Login information (required for type=1)',
+        description: 'Login information (required for login items)',
         properties: {
           username: {
             type: 'string',
@@ -229,41 +219,49 @@ export const createTool: Tool = {
       },
       folderId: {
         type: 'string',
-        description:
-          'Folder ID to assign the item to (only valid for items, not folders)',
+        description: 'Folder ID to assign the item to',
       },
     },
-    required: ['objectType', 'name'],
+    required: ['name', 'login'],
   },
 };
 
-export const editTool: Tool = {
-  name: 'edit',
-  description: 'Edit an existing item or folder in your vault',
+export const createFolderTool: Tool = {
+  name: 'create_folder',
+  description: 'Create a new folder in your vault',
   inputSchema: {
     type: 'object',
     properties: {
-      objectType: {
+      name: {
         type: 'string',
-        description: 'Type of object to edit',
-        enum: ['item', 'folder'],
+        description: 'Name of the folder',
       },
+    },
+    required: ['name'],
+  },
+};
+
+export const editItemTool: Tool = {
+  name: 'edit_item',
+  description: 'Edit an existing login item in your vault',
+  inputSchema: {
+    type: 'object',
+    properties: {
       id: {
         type: 'string',
-        description: 'ID of the item or folder to edit',
+        description: 'ID of the item to edit',
       },
       name: {
         type: 'string',
-        description: 'New name for the item or folder',
+        description: 'New name for the item',
       },
       notes: {
         type: 'string',
-        description:
-          'New notes for the item (only valid for items, not folders)',
+        description: 'New notes for the item',
       },
       login: {
         type: 'object',
-        description: 'Login information to update (only for items)',
+        description: 'Login information to update',
         properties: {
           username: {
             type: 'string',
@@ -301,11 +299,29 @@ export const editTool: Tool = {
       },
       folderId: {
         type: 'string',
-        description:
-          'New folder ID to assign the item to (only valid for items, not folders)',
+        description: 'New folder ID to assign the item to',
       },
     },
-    required: ['objectType', 'id'],
+    required: ['id'],
+  },
+};
+
+export const editFolderTool: Tool = {
+  name: 'edit_folder',
+  description: 'Edit an existing folder in your vault',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      id: {
+        type: 'string',
+        description: 'ID of the folder to edit',
+      },
+      name: {
+        type: 'string',
+        description: 'New name for the folder',
+      },
+    },
+    required: ['id', 'name'],
   },
 };
 
@@ -613,8 +629,10 @@ export const cliTools = [
   listTool,
   getTool,
   generateTool,
-  createTool,
-  editTool,
+  createItemTool,
+  createFolderTool,
+  editItemTool,
+  editFolderTool,
   deleteTool,
   confirmTool,
   createOrgCollectionTool,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -11,8 +11,10 @@ export {
   listTool,
   getTool,
   generateTool,
-  createTool,
-  editTool,
+  createItemTool,
+  createFolderTool,
+  editItemTool,
+  editFolderTool,
   deleteTool,
   cliTools,
 } from './cli.js';


### PR DESCRIPTION
## 📔 Objective

There was a one to one mapping of CLI create/edit commands to MCP tools. Since these tools are complex and handle multiple different types of data, it's worth breaking them apart into their own commands. This will better enable future work to add other item types such as credit cards, identities, and secure notes.