### PR TITLE
add other item types to create/edit tools

### DIFF
--- a/src/schemas/cli.ts
+++ b/src/schemas/cli.ts
@@ -163,17 +163,110 @@ export const loginSchema = z.object({
   totp: z.string().optional(),
 });
 
-// Schema for validating 'create item' command parameters
-export const createItemSchema = z.object({
-  // Name of the item to create
-  name: z.string().min(1, 'Name is required'),
-  // Optional notes for the item
-  notes: z.string().optional(),
-  // Login details (required for login items)
-  login: loginSchema,
-  // Folder ID to assign the item to
-  folderId: z.string().optional(),
+// Schema for validating card information in vault items
+export const cardSchema = z.object({
+  // Cardholder name
+  cardholderName: z.string().optional(),
+  // Card number
+  number: z.string().optional(),
+  // Card brand (Visa, Mastercard, Amex, Discover, etc.)
+  brand: z.string().optional(),
+  // Expiration month (MM)
+  expMonth: z.string().optional(),
+  // Expiration year (YYYY)
+  expYear: z.string().optional(),
+  // Security code (CVV)
+  code: z.string().optional(),
 });
+
+// Schema for validating identity information in vault items
+export const identitySchema = z.object({
+  // Title (Mr, Mrs, Ms, Dr, etc.)
+  title: z.string().optional(),
+  // First name
+  firstName: z.string().optional(),
+  // Middle name
+  middleName: z.string().optional(),
+  // Last name
+  lastName: z.string().optional(),
+  // Address line 1
+  address1: z.string().optional(),
+  // Address line 2
+  address2: z.string().optional(),
+  // Address line 3
+  address3: z.string().optional(),
+  // City
+  city: z.string().optional(),
+  // State or province
+  state: z.string().optional(),
+  // Postal code
+  postalCode: z.string().optional(),
+  // Country
+  country: z.string().optional(),
+  // Company name
+  company: z.string().optional(),
+  // Email address
+  email: z.string().optional(),
+  // Phone number
+  phone: z.string().optional(),
+  // Social Security Number
+  ssn: z.string().optional(),
+  // Username
+  username: z.string().optional(),
+  // Passport number
+  passportNumber: z.string().optional(),
+  // License number
+  licenseNumber: z.string().optional(),
+});
+
+// Schema for validating secure note information
+export const secureNoteSchema = z.object({
+  // Type of secure note (0: Generic)
+  type: z.literal(0).optional(),
+});
+
+// Schema for validating 'create item' command parameters
+export const createItemSchema = z
+  .object({
+    // Name of the item to create
+    name: z.string().min(1, 'Name is required'),
+    // Type of item (1: Login, 2: Secure Note, 3: Card, 4: Identity)
+    type: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+    // Optional notes for the item
+    notes: z.string().optional(),
+    // Login details (required for login items)
+    login: loginSchema.optional(),
+    // Card details (required for card items)
+    card: cardSchema.optional(),
+    // Identity details (required for identity items)
+    identity: identitySchema.optional(),
+    // Secure note details (required for secure note items)
+    secureNote: secureNoteSchema.optional(),
+    // Folder ID to assign the item to
+    folderId: z.string().optional(),
+  })
+  .refine(
+    (data) => {
+      // Validate that the appropriate type-specific data is provided
+      if (data.type === 1 && !data.login) {
+        return false;
+      }
+      if (data.type === 2 && !data.secureNote) {
+        return false;
+      }
+      if (data.type === 3 && !data.card) {
+        return false;
+      }
+      if (data.type === 4 && !data.identity) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message:
+        'Type-specific data is required: login for type 1, secureNote for type 2, card for type 3, identity for type 4',
+    },
+  );
 
 // Schema for validating 'create folder' command parameters
 export const createFolderSchema = z.object({
@@ -193,7 +286,69 @@ export const editLoginSchema = z.object({
   totp: z.string().optional(),
 });
 
-// Schema for validating 'edit item' command parameters (login)
+// Schema for validating card fields during item editing
+export const editCardSchema = z.object({
+  // Cardholder name
+  cardholderName: z.string().optional(),
+  // Card number
+  number: z.string().optional(),
+  // Card brand (Visa, Mastercard, Amex, Discover, etc.)
+  brand: z.string().optional(),
+  // Expiration month (MM)
+  expMonth: z.string().optional(),
+  // Expiration year (YYYY)
+  expYear: z.string().optional(),
+  // Security code (CVV)
+  code: z.string().optional(),
+});
+
+// Schema for validating identity fields during item editing
+export const editIdentitySchema = z.object({
+  // Title (Mr, Mrs, Ms, Dr, etc.)
+  title: z.string().optional(),
+  // First name
+  firstName: z.string().optional(),
+  // Middle name
+  middleName: z.string().optional(),
+  // Last name
+  lastName: z.string().optional(),
+  // Address line 1
+  address1: z.string().optional(),
+  // Address line 2
+  address2: z.string().optional(),
+  // Address line 3
+  address3: z.string().optional(),
+  // City
+  city: z.string().optional(),
+  // State or province
+  state: z.string().optional(),
+  // Postal code
+  postalCode: z.string().optional(),
+  // Country
+  country: z.string().optional(),
+  // Company name
+  company: z.string().optional(),
+  // Email address
+  email: z.string().optional(),
+  // Phone number
+  phone: z.string().optional(),
+  // Social Security Number
+  ssn: z.string().optional(),
+  // Username
+  username: z.string().optional(),
+  // Passport number
+  passportNumber: z.string().optional(),
+  // License number
+  licenseNumber: z.string().optional(),
+});
+
+// Schema for validating secure note fields during item editing
+export const editSecureNoteSchema = z.object({
+  // Type of secure note (0: Generic)
+  type: z.literal(0).optional(),
+});
+
+// Schema for validating 'edit item' command parameters
 export const editItemSchema = z.object({
   // ID of the item to edit
   id: z.string().min(1, 'ID is required'),
@@ -203,6 +358,12 @@ export const editItemSchema = z.object({
   notes: z.string().optional(),
   // Updated login information
   login: editLoginSchema.optional(),
+  // Updated card information
+  card: editCardSchema.optional(),
+  // Updated identity information
+  identity: editIdentitySchema.optional(),
+  // Updated secure note information
+  secureNote: editSecureNoteSchema.optional(),
   // New folder ID to assign the item to
   folderId: z.string().optional(),
 });

--- a/src/tools/cli.ts
+++ b/src/tools/cli.ts
@@ -175,13 +175,19 @@ export const createItemTool: Tool = {
         type: 'string',
         description: 'Name of the item',
       },
+      type: {
+        type: 'number',
+        description:
+          'Type of item to create (1: Login, 2: Secure Note, 3: Card, 4: Identity)',
+        enum: [1, 2, 3, 4],
+      },
       notes: {
         type: 'string',
         description: 'Notes for the item',
       },
       login: {
         type: 'object',
-        description: 'Login information (required for login items)',
+        description: 'Login information (required for type 1 - login items)',
         properties: {
           username: {
             type: 'string',
@@ -217,12 +223,133 @@ export const createItemTool: Tool = {
           },
         },
       },
+      secureNote: {
+        type: 'object',
+        description:
+          'Secure note information (required for type 2 - secure note items)',
+        properties: {
+          type: {
+            type: 'number',
+            description: 'Type of secure note (0: Generic)',
+            enum: [0],
+          },
+        },
+      },
+      card: {
+        type: 'object',
+        description: 'Card information (required for type 3 - card items)',
+        properties: {
+          cardholderName: {
+            type: 'string',
+            description: 'Cardholder name',
+          },
+          number: {
+            type: 'string',
+            description: 'Card number',
+          },
+          brand: {
+            type: 'string',
+            description: 'Card brand (Visa, Mastercard, Amex, Discover, etc.)',
+          },
+          expMonth: {
+            type: 'string',
+            description: 'Expiration month (MM)',
+          },
+          expYear: {
+            type: 'string',
+            description: 'Expiration year (YYYY)',
+          },
+          code: {
+            type: 'string',
+            description: 'Security code (CVV)',
+          },
+        },
+      },
+      identity: {
+        type: 'object',
+        description:
+          'Identity information (required for type 4 - identity items)',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Title (Mr, Mrs, Ms, Dr, etc.)',
+          },
+          firstName: {
+            type: 'string',
+            description: 'First name',
+          },
+          middleName: {
+            type: 'string',
+            description: 'Middle name',
+          },
+          lastName: {
+            type: 'string',
+            description: 'Last name',
+          },
+          address1: {
+            type: 'string',
+            description: 'Address line 1',
+          },
+          address2: {
+            type: 'string',
+            description: 'Address line 2',
+          },
+          address3: {
+            type: 'string',
+            description: 'Address line 3',
+          },
+          city: {
+            type: 'string',
+            description: 'City',
+          },
+          state: {
+            type: 'string',
+            description: 'State or province',
+          },
+          postalCode: {
+            type: 'string',
+            description: 'Postal code',
+          },
+          country: {
+            type: 'string',
+            description: 'Country',
+          },
+          company: {
+            type: 'string',
+            description: 'Company name',
+          },
+          email: {
+            type: 'string',
+            description: 'Email address',
+          },
+          phone: {
+            type: 'string',
+            description: 'Phone number',
+          },
+          ssn: {
+            type: 'string',
+            description: 'Social Security Number',
+          },
+          username: {
+            type: 'string',
+            description: 'Username',
+          },
+          passportNumber: {
+            type: 'string',
+            description: 'Passport number',
+          },
+          licenseNumber: {
+            type: 'string',
+            description: 'License number',
+          },
+        },
+      },
       folderId: {
         type: 'string',
         description: 'Folder ID to assign the item to',
       },
     },
-    required: ['name', 'login'],
+    required: ['name', 'type'],
   },
 };
 
@@ -243,7 +370,8 @@ export const createFolderTool: Tool = {
 
 export const editItemTool: Tool = {
   name: 'edit_item',
-  description: 'Edit an existing login item in your vault',
+  description:
+    'Edit an existing item (login, secure note, card, or identity) in your vault',
   inputSchema: {
     type: 'object',
     properties: {
@@ -294,6 +422,125 @@ export const editItemTool: Tool = {
           totp: {
             type: 'string',
             description: 'TOTP secret for the login',
+          },
+        },
+      },
+      secureNote: {
+        type: 'object',
+        description: 'Secure note information to update',
+        properties: {
+          type: {
+            type: 'number',
+            description: 'Type of secure note (0: Generic)',
+            enum: [0],
+          },
+        },
+      },
+      card: {
+        type: 'object',
+        description: 'Card information to update',
+        properties: {
+          cardholderName: {
+            type: 'string',
+            description: 'Cardholder name',
+          },
+          number: {
+            type: 'string',
+            description: 'Card number',
+          },
+          brand: {
+            type: 'string',
+            description: 'Card brand (Visa, Mastercard, Amex, Discover, etc.)',
+          },
+          expMonth: {
+            type: 'string',
+            description: 'Expiration month (MM)',
+          },
+          expYear: {
+            type: 'string',
+            description: 'Expiration year (YYYY)',
+          },
+          code: {
+            type: 'string',
+            description: 'Security code (CVV)',
+          },
+        },
+      },
+      identity: {
+        type: 'object',
+        description: 'Identity information to update',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'Title (Mr, Mrs, Ms, Dr, etc.)',
+          },
+          firstName: {
+            type: 'string',
+            description: 'First name',
+          },
+          middleName: {
+            type: 'string',
+            description: 'Middle name',
+          },
+          lastName: {
+            type: 'string',
+            description: 'Last name',
+          },
+          address1: {
+            type: 'string',
+            description: 'Address line 1',
+          },
+          address2: {
+            type: 'string',
+            description: 'Address line 2',
+          },
+          address3: {
+            type: 'string',
+            description: 'Address line 3',
+          },
+          city: {
+            type: 'string',
+            description: 'City',
+          },
+          state: {
+            type: 'string',
+            description: 'State or province',
+          },
+          postalCode: {
+            type: 'string',
+            description: 'Postal code',
+          },
+          country: {
+            type: 'string',
+            description: 'Country',
+          },
+          company: {
+            type: 'string',
+            description: 'Company name',
+          },
+          email: {
+            type: 'string',
+            description: 'Email address',
+          },
+          phone: {
+            type: 'string',
+            description: 'Phone number',
+          },
+          ssn: {
+            type: 'string',
+            description: 'Social Security Number',
+          },
+          username: {
+            type: 'string',
+            description: 'Username',
+          },
+          passportNumber: {
+            type: 'string',
+            description: 'Passport number',
+          },
+          licenseNumber: {
+            type: 'string',
+            description: 'License number',
           },
         },
       },

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -34,6 +34,37 @@ export interface BitwardenItem {
     }[];
     totp?: string;
   };
+  card?: {
+    cardholderName?: string;
+    number?: string;
+    brand?: string;
+    expMonth?: string;
+    expYear?: string;
+    code?: string;
+  };
+  identity?: {
+    title?: string;
+    firstName?: string;
+    middleName?: string;
+    lastName?: string;
+    address1?: string;
+    address2?: string;
+    address3?: string;
+    city?: string;
+    state?: string;
+    postalCode?: string;
+    country?: string;
+    company?: string;
+    email?: string;
+    phone?: string;
+    ssn?: string;
+    username?: string;
+    passportNumber?: string;
+    licenseNumber?: string;
+  };
+  secureNote?: {
+    type?: number;
+  };
 }
 
 export interface BitwardenFolder {

--- a/tests/cli-commands.spec.ts
+++ b/tests/cli-commands.spec.ts
@@ -987,4 +987,614 @@ describe('CLI Commands', () => {
       }
     });
   });
+
+  describe('create item validation', () => {
+    // Simplified URI schema for testing
+    const uriSchema = z.object({
+      uri: z.string().url('Must be a valid URL'),
+      match: z
+        .union([
+          z.literal(0),
+          z.literal(1),
+          z.literal(2),
+          z.literal(3),
+          z.literal(4),
+          z.literal(5),
+        ])
+        .optional(),
+    });
+
+    const loginSchema = z.object({
+      username: z.string().optional(),
+      password: z.string().optional(),
+      uris: z.array(uriSchema).optional(),
+      totp: z.string().optional(),
+    });
+
+    const cardSchema = z.object({
+      cardholderName: z.string().optional(),
+      number: z.string().optional(),
+      brand: z.string().optional(),
+      expMonth: z.string().optional(),
+      expYear: z.string().optional(),
+      code: z.string().optional(),
+    });
+
+    const identitySchema = z.object({
+      title: z.string().optional(),
+      firstName: z.string().optional(),
+      middleName: z.string().optional(),
+      lastName: z.string().optional(),
+      address1: z.string().optional(),
+      address2: z.string().optional(),
+      address3: z.string().optional(),
+      city: z.string().optional(),
+      state: z.string().optional(),
+      postalCode: z.string().optional(),
+      country: z.string().optional(),
+      company: z.string().optional(),
+      email: z.string().optional(),
+      phone: z.string().optional(),
+      ssn: z.string().optional(),
+      username: z.string().optional(),
+      passportNumber: z.string().optional(),
+      licenseNumber: z.string().optional(),
+    });
+
+    const secureNoteSchema = z.object({
+      type: z.literal(0).optional(),
+    });
+
+    const createItemSchema = z
+      .object({
+        name: z.string().min(1, 'Name is required'),
+        type: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(4)]),
+        notes: z.string().optional(),
+        login: loginSchema.optional(),
+        card: cardSchema.optional(),
+        identity: identitySchema.optional(),
+        secureNote: secureNoteSchema.optional(),
+        folderId: z.string().optional(),
+      })
+      .refine(
+        (data) => {
+          if (data.type === 1 && !data.login) return false;
+          if (data.type === 2 && !data.secureNote) return false;
+          if (data.type === 3 && !data.card) return false;
+          if (data.type === 4 && !data.identity) return false;
+          return true;
+        },
+        {
+          message:
+            'Type-specific data is required: login for type 1, secureNote for type 2, card for type 3, identity for type 4',
+        },
+      );
+
+    it('should validate create login item with all fields', () => {
+      const validInput = {
+        name: 'Test Login',
+        type: 1 as const,
+        notes: 'Test notes',
+        login: {
+          username: 'user@example.com',
+          password: 'password123',
+          uris: [{ uri: 'https://example.com', match: 0 as const }],
+          totp: 'JBSWY3DPEHPK3PXP',
+        },
+        folderId: 'folder-123',
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate create login item with minimal fields', () => {
+      const validInput = {
+        name: 'Test Login',
+        type: 1 as const,
+        login: {},
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate create secure note item', () => {
+      const validInput = {
+        name: 'Test Secure Note',
+        type: 2 as const,
+        notes: 'This is a secure note',
+        secureNote: { type: 0 as const },
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate create card item with all fields', () => {
+      const validInput = {
+        name: 'Test Card',
+        type: 3 as const,
+        card: {
+          cardholderName: 'John Doe',
+          number: '4111111111111111',
+          brand: 'Visa',
+          expMonth: '12',
+          expYear: '2025',
+          code: '123',
+        },
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate create identity item with all fields', () => {
+      const validInput = {
+        name: 'Test Identity',
+        type: 4 as const,
+        identity: {
+          title: 'Mr',
+          firstName: 'John',
+          middleName: 'M',
+          lastName: 'Doe',
+          address1: '123 Main St',
+          city: 'New York',
+          state: 'NY',
+          postalCode: '10001',
+          country: 'USA',
+          email: 'john@example.com',
+          phone: '555-1234',
+          ssn: '123-45-6789',
+        },
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should reject create item without name', () => {
+      const invalidInput = {
+        type: 1 as const,
+        login: { username: 'test' },
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Validation error');
+      }
+    });
+
+    it('should reject create item without type', () => {
+      const invalidInput = {
+        name: 'Test Item',
+        login: { username: 'test' },
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Validation error');
+      }
+    });
+
+    it('should reject create login item without login data', () => {
+      const invalidInput = {
+        name: 'Test Login',
+        type: 1 as const,
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain(
+          'Type-specific data is required',
+        );
+      }
+    });
+
+    it('should reject create secure note without secureNote data', () => {
+      const invalidInput = {
+        name: 'Test Note',
+        type: 2 as const,
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain(
+          'Type-specific data is required',
+        );
+      }
+    });
+
+    it('should reject create card without card data', () => {
+      const invalidInput = {
+        name: 'Test Card',
+        type: 3 as const,
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain(
+          'Type-specific data is required',
+        );
+      }
+    });
+
+    it('should reject create identity without identity data', () => {
+      const invalidInput = {
+        name: 'Test Identity',
+        type: 4 as const,
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain(
+          'Type-specific data is required',
+        );
+      }
+    });
+
+    it('should reject create item with invalid URI', () => {
+      const invalidInput = {
+        name: 'Test Login',
+        type: 1 as const,
+        login: {
+          uris: [{ uri: 'not-a-url' }],
+        },
+      };
+
+      const [isValid, result] = validateInput(createItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Must be a valid URL');
+      }
+    });
+  });
+
+  describe('edit item validation', () => {
+    const uriSchema = z.object({
+      uri: z.string().url('Must be a valid URL'),
+      match: z
+        .union([
+          z.literal(0),
+          z.literal(1),
+          z.literal(2),
+          z.literal(3),
+          z.literal(4),
+          z.literal(5),
+        ])
+        .optional(),
+    });
+
+    const editLoginSchema = z.object({
+      username: z.string().optional(),
+      password: z.string().optional(),
+      uris: z.array(uriSchema).optional(),
+      totp: z.string().optional(),
+    });
+
+    const editCardSchema = z.object({
+      cardholderName: z.string().optional(),
+      number: z.string().optional(),
+      brand: z.string().optional(),
+      expMonth: z.string().optional(),
+      expYear: z.string().optional(),
+      code: z.string().optional(),
+    });
+
+    const editIdentitySchema = z.object({
+      title: z.string().optional(),
+      firstName: z.string().optional(),
+      middleName: z.string().optional(),
+      lastName: z.string().optional(),
+      address1: z.string().optional(),
+      address2: z.string().optional(),
+      address3: z.string().optional(),
+      city: z.string().optional(),
+      state: z.string().optional(),
+      postalCode: z.string().optional(),
+      country: z.string().optional(),
+      company: z.string().optional(),
+      email: z.string().optional(),
+      phone: z.string().optional(),
+      ssn: z.string().optional(),
+      username: z.string().optional(),
+      passportNumber: z.string().optional(),
+      licenseNumber: z.string().optional(),
+    });
+
+    const editSecureNoteSchema = z.object({
+      type: z.literal(0).optional(),
+    });
+
+    const editItemSchema = z.object({
+      id: z.string().min(1, 'ID is required'),
+      name: z.string().optional(),
+      notes: z.string().optional(),
+      login: editLoginSchema.optional(),
+      card: editCardSchema.optional(),
+      identity: editIdentitySchema.optional(),
+      secureNote: editSecureNoteSchema.optional(),
+      folderId: z.string().optional(),
+    });
+
+    it('should validate edit item with id only', () => {
+      const validInput = {
+        id: 'item-123',
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate edit login item with all fields', () => {
+      const validInput = {
+        id: 'item-123',
+        name: 'Updated Login',
+        notes: 'Updated notes',
+        login: {
+          username: 'newuser@example.com',
+          password: 'newpassword',
+          uris: [{ uri: 'https://newsite.com' }],
+          totp: 'NEWTOTP',
+        },
+        folderId: 'folder-456',
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate edit card item', () => {
+      const validInput = {
+        id: 'item-123',
+        card: {
+          cardholderName: 'Jane Doe',
+          expMonth: '06',
+          expYear: '2026',
+        },
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate edit identity item', () => {
+      const validInput = {
+        id: 'item-123',
+        identity: {
+          firstName: 'Jane',
+          lastName: 'Smith',
+          email: 'jane@example.com',
+        },
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should validate edit secure note', () => {
+      const validInput = {
+        id: 'item-123',
+        notes: 'Updated secure note content',
+        secureNote: { type: 0 as const },
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should reject edit item without id', () => {
+      const invalidInput = {
+        name: 'Updated Item',
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Validation error');
+      }
+    });
+
+    it('should reject edit item with empty id', () => {
+      const invalidInput = {
+        id: '',
+        name: 'Updated Item',
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('ID is required');
+      }
+    });
+
+    it('should reject edit item with invalid URI', () => {
+      const invalidInput = {
+        id: 'item-123',
+        login: {
+          uris: [{ uri: 'invalid-url' }],
+        },
+      };
+
+      const [isValid, result] = validateInput(editItemSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Must be a valid URL');
+      }
+    });
+  });
+
+  describe('create folder validation', () => {
+    const createFolderSchema = z.object({
+      name: z.string().min(1, 'Name is required'),
+    });
+
+    it('should validate create folder with name', () => {
+      const validInput = {
+        name: 'Test Folder',
+      };
+
+      const [isValid, result] = validateInput(createFolderSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should reject create folder without name', () => {
+      const invalidInput = {};
+
+      const [isValid, result] = validateInput(createFolderSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Validation error');
+      }
+    });
+
+    it('should reject create folder with empty name', () => {
+      const invalidInput = {
+        name: '',
+      };
+
+      const [isValid, result] = validateInput(createFolderSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Name is required');
+      }
+    });
+  });
+
+  describe('edit folder validation', () => {
+    const editFolderSchema = z.object({
+      id: z.string().min(1, 'ID is required'),
+      name: z.string().min(1, 'Name is required'),
+    });
+
+    it('should validate edit folder with id and name', () => {
+      const validInput = {
+        id: 'folder-123',
+        name: 'Updated Folder',
+      };
+
+      const [isValid, result] = validateInput(editFolderSchema, validInput);
+
+      expect(isValid).toBe(true);
+      if (isValid) {
+        expect(result).toEqual(validInput);
+      }
+    });
+
+    it('should reject edit folder without id', () => {
+      const invalidInput = {
+        name: 'Updated Folder',
+      };
+
+      const [isValid, result] = validateInput(editFolderSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Validation error');
+      }
+    });
+
+    it('should reject edit folder without name', () => {
+      const invalidInput = {
+        id: 'folder-123',
+      };
+
+      const [isValid, result] = validateInput(editFolderSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Validation error');
+      }
+    });
+
+    it('should reject edit folder with empty id', () => {
+      const invalidInput = {
+        id: '',
+        name: 'Updated Folder',
+      };
+
+      const [isValid, result] = validateInput(editFolderSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('ID is required');
+      }
+    });
+
+    it('should reject edit folder with empty name', () => {
+      const invalidInput = {
+        id: 'folder-123',
+        name: '',
+      };
+
+      const [isValid, result] = validateInput(editFolderSchema, invalidInput);
+
+      expect(isValid).toBe(false);
+      if (!isValid) {
+        expect(result.content[0].text).toContain('Name is required');
+      }
+    });
+  });
 });


### PR DESCRIPTION
## 📔 Objective

The create and edit tools did not support cards, identities, and secure notes. This PR adds support for those item types and also adds missing tests for the create and edit CLI command tools.