### PR TITLE
[PM-34802] Fix server not starting when invoked via npx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -277,8 +277,16 @@ async function runServer(): Promise<void> {
 }
 
 // Only run the server if this file is executed directly
-// Check if this is the main module by comparing file paths
-const isMainModule = process.argv[1] && process.argv[1].endsWith('index.js');
+// Check if this is the main module by comparing real paths (resolving symlinks)
+// This ensures it works when invoked via npx, where process.argv[1] is a symlink
+// like "mcp-server-bitwarden" that doesn't end with "index.js"
+import { realpathSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const currentFile = fileURLToPath(import.meta.url);
+const isMainModule =
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === realpathSync(currentFile);
 if (isMainModule) {
   runServer().catch((error) => {
     console.error('Fatal error running server:', error);


### PR DESCRIPTION
## Summary
- The `isMainModule` check uses `endsWith('index.js')` on `process.argv[1]`, but when run via `npx`, the entry point is invoked through a symlink named `mcp-server-bitwarden` (from the `bin` field in package.json), which doesn't match
- This causes the server to silently exit without ever calling `runServer()`, making `npx -y @bitwarden/mcp-server` non-functional
- Fixed by using `realpathSync` to resolve symlinks before comparing paths, so the check works regardless of invocation method

## Reproduction
```json
{
  "mcpServers": {
    "bitwarden": {
      "command": "npx",
      "args": ["-y", "@bitwarden/mcp-server"],
      "env": { "BW_SESSION": "..." }
    }
  }
}
```
The server starts, receives the `initialize` message, then the transport closes immediately because `runServer()` was never called.

## Test plan
- [ ] Verify server starts correctly when invoked via `npx -y @bitwarden/mcp-server`
- [ ] Verify server starts correctly when invoked via `node dist/index.js`
- [ ] Verify server does NOT start when imported as a library module

🤖 Generated with [Claude Code](https://claude.com/claude-code)