### PR TITLE
[PM-35353] feat: support custom fields, organizationId and collectionIds on items

### DIFF
--- a/src/handlers/cli.ts
+++ b/src/handlers/cli.ts
@@ -157,8 +157,19 @@ export const handleGenerate = withValidation(
 export const handleCreateItem = withValidation(
   createItemSchema,
   async (validatedArgs) => {
-    const { name, type, notes, login, card, identity, secureNote, folderId } =
-      validatedArgs;
+    const {
+      name,
+      type,
+      notes,
+      login,
+      card,
+      identity,
+      secureNote,
+      folderId,
+      organizationId,
+      collectionIds,
+      fields,
+    } = validatedArgs;
 
     // Creating an item with the specified type
     const item: BitwardenItem = {
@@ -172,6 +183,22 @@ export const handleCreateItem = withValidation(
 
     if (folderId !== undefined) {
       item.folderId = folderId;
+    }
+
+    if (organizationId !== undefined) {
+      item.organizationId = organizationId;
+    }
+
+    if (collectionIds !== undefined) {
+      item.collectionIds = collectionIds;
+    }
+
+    if (fields !== undefined) {
+      item.fields = fields.map((f) => ({
+        name: f.name,
+        value: f.value ?? null,
+        type: f.type ?? 0,
+      }));
     }
 
     // Set type-specific data based on item type
@@ -237,7 +264,13 @@ export const handleCreateItem = withValidation(
 
     const itemJson = JSON.stringify(item);
     const encodedItem = Buffer.from(itemJson).toString('base64');
-    const response = await executeCliCommand('create', ['item', encodedItem]);
+    // When the item belongs to an organization, bw CLI requires the
+    // --organizationid flag in addition to the ID inside the JSON.
+    const cliArgs = ['item', encodedItem];
+    if (organizationId !== undefined) {
+      cliArgs.push('--organizationid', organizationId);
+    }
+    const response = await executeCliCommand('create', cliArgs);
     return toMcpFormat(response);
   },
 );
@@ -258,8 +291,19 @@ export const handleCreateFolder = withValidation(
 export const handleEditItem = withValidation(
   editItemSchema,
   async (validatedArgs) => {
-    const { id, name, notes, login, card, identity, secureNote, folderId } =
-      validatedArgs;
+    const {
+      id,
+      name,
+      notes,
+      login,
+      card,
+      identity,
+      secureNote,
+      folderId,
+      organizationId,
+      collectionIds,
+      fields,
+    } = validatedArgs;
 
     // First, get the existing item
     const getResponse = await executeCliCommand('get', ['item', id]);
@@ -278,6 +322,19 @@ export const handleEditItem = withValidation(
       if (name !== undefined) existingItem.name = name;
       if (notes !== undefined) existingItem.notes = notes;
       if (folderId !== undefined) existingItem.folderId = folderId;
+      if (organizationId !== undefined)
+        existingItem.organizationId = organizationId;
+      if (collectionIds !== undefined)
+        existingItem.collectionIds = collectionIds;
+      // Custom fields: when provided, replace the array entirely. Callers that
+      // want to preserve existing fields should read the item first and merge.
+      if (fields !== undefined) {
+        existingItem.fields = fields.map((f) => ({
+          name: f.name,
+          value: f.value ?? null,
+          type: f.type ?? 0,
+        }));
+      }
 
       // Update type-specific data
       if (login !== undefined) {

--- a/src/schemas/cli.ts
+++ b/src/schemas/cli.ts
@@ -249,6 +249,19 @@ export const secureNoteSchema = z.object({
   type: z.literal(0).optional(),
 });
 
+// Schema for a single custom field on a vault item
+export const customFieldSchema = z.object({
+  // Name of the custom field
+  name: z.string().min(1, 'Field name is required'),
+  // Value of the custom field (null is allowed for empty)
+  value: z.string().nullable().optional(),
+  // Type of custom field (0: Text, 1: Hidden, 2: Boolean, 3: Linked)
+  type: z
+    .union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)])
+    .optional()
+    .default(0),
+});
+
 // Schema for validating 'create item' command parameters
 export const createItemSchema = z
   .object({
@@ -268,6 +281,12 @@ export const createItemSchema = z
     secureNote: secureNoteSchema.optional(),
     // Folder ID to assign the item to
     folderId: z.string().optional(),
+    // Organization ID (required to create items shared with an organization)
+    organizationId: z.string().optional(),
+    // Collection IDs (used with organizationId to place the item in one or more shared collections)
+    collectionIds: z.array(z.string()).optional(),
+    // Custom fields attached to the item
+    fields: z.array(customFieldSchema).optional(),
   })
   .refine(
     (data) => {
@@ -396,6 +415,12 @@ export const editItemSchema = z.object({
   secureNote: editSecureNoteSchema.optional(),
   // New folder ID to assign the item to
   folderId: z.string().optional(),
+  // New organization ID (to move the item to/between organizations)
+  organizationId: z.string().optional(),
+  // New collection IDs; replaces the existing assignment when provided
+  collectionIds: z.array(z.string()).optional(),
+  // Custom fields; when provided, replaces the existing custom fields array entirely
+  fields: z.array(customFieldSchema).optional(),
 });
 
 // Schema for validating 'edit folder' command parameters

--- a/src/tools/cli.ts
+++ b/src/tools/cli.ts
@@ -363,6 +363,38 @@ export const createItemTool: Tool = {
         type: 'string',
         description: 'Folder ID to assign the item to',
       },
+      organizationId: {
+        type: 'string',
+        description:
+          'Organization ID. Required when the item should be shared with an organization/collection.',
+      },
+      collectionIds: {
+        type: 'array',
+        description:
+          'Collection IDs within the organization. Must be used together with organizationId.',
+        items: { type: 'string' },
+      },
+      fields: {
+        type: 'array',
+        description: 'Custom fields attached to the item',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Name of the custom field' },
+            value: {
+              type: 'string',
+              description: 'Value of the custom field',
+            },
+            type: {
+              type: 'number',
+              description:
+                'Field type (0: Text, 1: Hidden, 2: Boolean, 3: Linked)',
+              enum: [0, 1, 2, 3],
+            },
+          },
+          required: ['name'],
+        },
+      },
     },
     required: ['name', 'type'],
   },
@@ -562,6 +594,39 @@ export const editItemTool: Tool = {
       folderId: {
         type: 'string',
         description: 'New folder ID to assign the item to',
+      },
+      organizationId: {
+        type: 'string',
+        description:
+          'New organization ID (to move the item to/between organizations)',
+      },
+      collectionIds: {
+        type: 'array',
+        description:
+          'New collection IDs; replaces the existing assignment when provided',
+        items: { type: 'string' },
+      },
+      fields: {
+        type: 'array',
+        description:
+          'Custom fields; when provided, replaces the existing custom fields array entirely',
+        items: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Name of the custom field' },
+            value: {
+              type: 'string',
+              description: 'Value of the custom field',
+            },
+            type: {
+              type: 'number',
+              description:
+                'Field type (0: Text, 1: Hidden, 2: Boolean, 3: Linked)',
+              enum: [0, 1, 2, 3],
+            },
+          },
+          required: ['name'],
+        },
       },
     },
     required: ['id'],

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -25,6 +25,13 @@ export interface BitwardenItem {
   notes?: string;
   type?: number;
   folderId?: string;
+  organizationId?: string;
+  collectionIds?: readonly string[];
+  fields?: readonly {
+    readonly name: string;
+    readonly value?: string | null;
+    readonly type: number;
+  }[];
   login?: {
     username?: string;
     password?: string;


### PR DESCRIPTION
## Summary

The `create_item` and `edit_item` tools currently expose only `name`, `type`, `login`/`card`/`identity`/`secureNote` and `folderId`. This forces MCP consumers to drop down to the `bw` CLI directly whenever they need to:

- Create or update a vault item with **custom fields**
- Put an item inside an **organization + collection**
- Rename or migrate a custom field on an existing item

The underlying `bw` CLI already understands all three (fields are part of the item JSON; `organizationId`/`collectionIds` live in the same object; the CLI also needs `--organizationid` as a flag at create time), so this PR just surfaces them through the MCP schema and threads them through the handler.

## Changes

- **`src/utils/types.ts`** — extend `BitwardenItem` with `fields`, `organizationId`, `collectionIds`.
- **`src/schemas/cli.ts`** — new `customFieldSchema` (name + optional value + type 0..3) and extensions to `createItemSchema`/`editItemSchema`.
- **`src/handlers/cli.ts`** —
  - `handleCreateItem` copies `organizationId`/`collectionIds`/`fields` into the JSON item and appends `--organizationid <id>` when present.
  - `handleEditItem` updates `organizationId`/`collectionIds` and replaces the fields array on the existing item when one is supplied (callers that want to merge should read the item first and merge client-side).
- **`src/tools/cli.ts`** — exposes the new parameters to MCP clients for both `create_item` and `edit_item`.

Backward compatible: all new parameters are optional; existing calls behave identically when they're omitted.

## Motivation

Encountered while using the MCP server from an assistant to populate Bitwarden with SSH credentials that need a `muxterm_init_path`-style custom field (for a tool that reads the field and auto-cd's into that directory after login). Without this PR, the only way to create the items with the custom field is to shell out to `bw edit item <id> <base64>` directly or to wrap the MCP in a consumer-specific API.

## Test plan

- [x] `npm run build` compiles cleanly (no TypeScript errors)
- [x] Manually verified custom field + organization + collection round-trip against a self-hosted Vaultwarden via the modified MCP (login item created with `Initial_Path` field lands in the correct collection, readable back via `get item`)
- [ ] Existing test suite runs — `tests/cli-commands.spec.ts` has pre-existing test timeouts in my environment (unrelated tests, no change in pass/fail counts from my diff). Happy to adjust if CI flags anything new.