### PR TITLE
[VULN-551] fix: Require BW_ALLOWED_DIRECTORIES for file operations

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -148,7 +148,7 @@ export BW_ALLOWED_DIRECTORIES="/home/user/downloads,/tmp/bitwarden-files"
 set BW_ALLOWED_DIRECTORIES=C:/Users/YourName/Documents,C:/Temp/Bitwarden
 ```
 
-**Default Behavior**: If not configured, defaults to system temp directory (`os.tmpdir()/bitwarden-files`)
+**Default Behavior**: If `BW_ALLOWED_DIRECTORIES` is unset or empty, `validateFilePath()` rejects every path (fail-closed). File-based tools require explicit opt-in via the env var.
 
 **Protects Against**:
 

--- a/README.md
+++ b/README.md
@@ -170,14 +170,14 @@ Any MCP-compatible client can connect to this server via stdio transport. Refer 
 
 ### Environment Variables
 
-| Variable                 | Required For    | Description                                      | Default                            |
-| ------------------------ | --------------- | ------------------------------------------------ | ---------------------------------- |
-| `BW_SESSION`             | CLI operations  | Session token from `bw unlock --raw`             | -                                  |
-| `BW_CLIENT_ID`           | API operations  | Organization API client ID                       | -                                  |
-| `BW_CLIENT_SECRET`       | API operations  | Organization API client secret                   | -                                  |
-| `BW_API_BASE_URL`        | API operations  | Bitwarden API base URL                           | `https://api.bitwarden.com`        |
-| `BW_IDENTITY_URL`        | API operations  | OAuth2 identity server URL                       | `https://identity.bitwarden.com`   |
-| `BW_ALLOWED_DIRECTORIES` | File operations | Comma-separated list of allowed file directories | `os.tmpdir() + '/bitwarden-files'` |
+| Variable                 | Required For    | Description                                                                                                                                                                       | Default                          |
+| ------------------------ | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `BW_SESSION`             | CLI operations  | Session token from `bw unlock --raw`                                                                                                                                              | -                                |
+| `BW_CLIENT_ID`           | API operations  | Organization API client ID                                                                                                                                                        | -                                |
+| `BW_CLIENT_SECRET`       | API operations  | Organization API client secret                                                                                                                                                    | -                                |
+| `BW_API_BASE_URL`        | API operations  | Bitwarden API base URL                                                                                                                                                            | `https://api.bitwarden.com`      |
+| `BW_IDENTITY_URL`        | API operations  | OAuth2 identity server URL                                                                                                                                                        | `https://identity.bitwarden.com` |
+| `BW_ALLOWED_DIRECTORIES` | File operations | Comma-separated list of allowed file directories. **Required** for file-based tools (e.g. `create_file_send`, `create_attachment`); when unset, all file operations are rejected. | -                                |
 
 **Note:** For self-hosted Bitwarden instances, set `BW_API_BASE_URL` and `BW_IDENTITY_URL` to your server URLs.
 

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -3,7 +3,6 @@
  */
 
 import path from 'path';
-import os from 'os';
 
 /**
  * Sanitizes a string to prevent command injection by removing dangerous characters
@@ -200,7 +199,8 @@ export function sanitizeApiParameters(params: unknown): unknown {
  *
  * Configuration:
  * Set BW_ALLOWED_DIRECTORIES environment variable to a comma-separated list
- * of allowed directories. If not set, defaults to system temp directory.
+ * of allowed directories. If not set (or empty), file operations are
+ * rejected — explicit opt-in is required.
  *
  * Example: BW_ALLOWED_DIRECTORIES=/tmp/bitwarden,/home/user/downloads
  */
@@ -286,20 +286,23 @@ export function validateFilePath(filePath: string): boolean {
     const resolvedPath = path.resolve(normalizedPath);
 
     // Step 9: Get allowed directories from environment variable
+    // Fail closed: if BW_ALLOWED_DIRECTORIES is unset, reject all file operations.
+    // Defaulting to a world-writable location (e.g. /tmp on Linux/macOS) would
+    // allow other local users or services to stage files for the AI agent to
+    // read or send, so explicit opt-in is required.
     const allowedDirsEnv = process.env['BW_ALLOWED_DIRECTORIES'];
+    if (!allowedDirsEnv || !allowedDirsEnv.trim()) {
+      return false;
+    }
 
-    let allowedDirectories: string[];
-    if (allowedDirsEnv && allowedDirsEnv.trim()) {
-      // Parse comma-separated list and resolve each to absolute path
-      allowedDirectories = allowedDirsEnv
-        .split(',')
-        .map((dir) => dir.trim())
-        .filter((dir) => dir.length > 0)
-        .map((dir) => path.resolve(dir));
-    } else {
-      // Default to system temp directory if no whitelist configured
-      const defaultDir = path.join(os.tmpdir(), 'bitwarden-files');
-      allowedDirectories = [defaultDir];
+    const allowedDirectories = allowedDirsEnv
+      .split(',')
+      .map((dir) => dir.trim())
+      .filter((dir) => dir.length > 0)
+      .map((dir) => path.resolve(dir));
+
+    if (allowedDirectories.length === 0) {
+      return false;
     }
 
     // Step 10: Verify resolved path starts with one of the allowed directories

--- a/tests/security.spec.ts
+++ b/tests/security.spec.ts
@@ -698,6 +698,31 @@ describe('Security - Command Injection Protection', () => {
         // We just verify the function doesn't crash
         expect(typeof result).toBe('boolean');
       });
+
+      it('should reject all paths when BW_ALLOWED_DIRECTORIES is unset', () => {
+        delete process.env['BW_ALLOWED_DIRECTORIES'];
+
+        const candidatePaths = [
+          '/tmp/bitwarden-files/file.txt',
+          '/tmp/file.txt',
+          'document.pdf',
+          'C:/Users/me/file.txt',
+        ];
+
+        candidatePaths.forEach((path) => {
+          expect(validateFilePath(path)).toBe(false);
+        });
+      });
+
+      it('should reject all paths when BW_ALLOWED_DIRECTORIES is empty or whitespace', () => {
+        const emptyValues = ['', '   ', ',', ' , , '];
+
+        emptyValues.forEach((value) => {
+          process.env['BW_ALLOWED_DIRECTORIES'] = value;
+          expect(validateFilePath('/tmp/bitwarden-files/file.txt')).toBe(false);
+          expect(validateFilePath('document.pdf')).toBe(false);
+        });
+      });
     });
 
     describe('Edge Cases and Error Handling', () => {


### PR DESCRIPTION
## 🎟️ Tracking

[VULN-551](https://bitwarden.atlassian.net/browse/VULN-551) — security-focused suggestion was closed as not-a-vulnerability but agreed a hardening change was warranted.

## 📔 Objective

When `BW_ALLOWED_DIRECTORIES` was unset, `validateFilePath` previously fell back to allowing files under `os.tmpdir()/bitwarden-files`. On Linux/macOS that lives under a world-writable `/tmp`, where any local user (or service account such as `www-data`) could create the directory and stage files for the AI agent to read or send via `create_file_send`, `create_attachment`, or attachment downloads.

This change drops the implicit fallback and fails closed: when no allowlist is configured, every file path is rejected and the file-based tools surface a Zod validation error. Operators must explicitly opt in via the env var.

- `src/utils/security.ts` — remove `os.tmpdir()` default; reject when env is unset, empty, or whitespace/comma-only.
- `tests/security.spec.ts` — add fail-closed coverage for unset and empty values.
- `README.md` and `.claude/CLAUDE.md` — document the new required-opt-in behavior.

[VULN-551]: https://bitwarden.atlassian.net/browse/VULN-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ