### PR TITLE
Harden Docker build, lock-file CI install, and OAuth token caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: ${{ steps.retrieve-node-version.outputs.node_version }}
 
       - name: Install Node dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY package.json package-lock.json tsconfig.json ./
 
 RUN npm ci --ignore-scripts --omit-dev
-RUN npm install @bitwarden/cli@2025.7.0
+RUN npm install --ignore-scripts @bitwarden/cli@2025.7.0
 
 FROM dependencies AS builder
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -13,19 +13,9 @@ import type { ApiResponse, TokenResponse } from './types.js';
 
 let cachedToken: string | null = null;
 let tokenExpiry: number = 0;
+let inFlightTokenRequest: Promise<string> | null = null;
 
-/**
- * Obtains an OAuth2 access token using client credentials flow
- * Caches tokens and automatically refreshes when expired
- */
-export async function getAccessToken(): Promise<string> {
-  const now = Date.now();
-
-  // Return cached token if still valid (with 5 minute buffer)
-  if (cachedToken && now < tokenExpiry - 300000) {
-    return cachedToken;
-  }
-
+async function fetchNewAccessToken(): Promise<string> {
   if (!CLIENT_ID || !CLIENT_SECRET) {
     throw new Error(
       'BW_CLIENT_ID and BW_CLIENT_SECRET environment variables are required for API operations',
@@ -55,7 +45,7 @@ export async function getAccessToken(): Promise<string> {
     const tokenData: TokenResponse = (await response.json()) as TokenResponse;
 
     cachedToken = tokenData.access_token;
-    tokenExpiry = now + tokenData.expires_in * 1000; // Convert seconds to milliseconds
+    tokenExpiry = Date.now() + tokenData.expires_in * 1000; // Convert seconds to milliseconds
 
     return cachedToken;
   } catch (error) {
@@ -63,6 +53,32 @@ export async function getAccessToken(): Promise<string> {
       `Failed to obtain access token: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
+}
+
+/**
+ * Obtains an OAuth2 access token using client credentials flow.
+ * Caches tokens and automatically refreshes when expired.
+ * Deduplicates concurrent callers so only one network request is in flight
+ * at a time when the cache is cold or expired.
+ */
+export async function getAccessToken(): Promise<string> {
+  const now = Date.now();
+
+  // Return cached token if still valid (with 5 minute buffer)
+  if (cachedToken && now < tokenExpiry - 300000) {
+    return cachedToken;
+  }
+
+  // If a refresh is already in flight, wait for it instead of starting another.
+  if (inFlightTokenRequest) {
+    return inFlightTokenRequest;
+  }
+
+  inFlightTokenRequest = fetchNewAccessToken().finally(() => {
+    inFlightTokenRequest = null;
+  });
+
+  return inFlightTokenRequest;
 }
 
 /**

--- a/tests/utils/api.spec.ts
+++ b/tests/utils/api.spec.ts
@@ -129,6 +129,48 @@ describe('API Utilities', () => {
         'Failed to obtain access token: Network error',
       );
     });
+
+    it('should deduplicate concurrent token requests when the cache is cold', async () => {
+      const { getAccessToken } = await import('../../src/utils/api.js');
+
+      // Hold the single fetch open so several callers can pile up behind it.
+      let resolveFetch: ((value: Response) => void) | undefined;
+      const pendingFetch = new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+      mockFetch.mockReturnValueOnce(pendingFetch);
+
+      const concurrentCallers = Promise.all([
+        getAccessToken(),
+        getAccessToken(),
+        getAccessToken(),
+        getAccessToken(),
+        getAccessToken(),
+      ]);
+
+      resolveFetch!({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve({
+            access_token: 'concurrent-test-token',
+            token_type: 'Bearer',
+            expires_in: 3600,
+          }),
+      } as Response);
+
+      const tokens = await concurrentCallers;
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(tokens).toEqual([
+        'concurrent-test-token',
+        'concurrent-test-token',
+        'concurrent-test-token',
+        'concurrent-test-token',
+        'concurrent-test-token',
+      ]);
+    });
   });
 
   describe('buildSafeApiRequest', () => {


### PR DESCRIPTION
## Summary

Three small, independent hardening fixes found while auditing the codebase locally:

- **`Dockerfile`** — add `--ignore-scripts` to `npm install @bitwarden/cli@2025.7.0`. The line above already hardens `npm ci` with `--ignore-scripts --omit-dev`, but the `@bitwarden/cli` install was left running lifecycle scripts as root in the `dependencies` stage.
- **`.github/workflows/build.yml`** — switch `npm install` to `npm ci`. The test workflow already uses `npm ci`; build.yml diverged and could silently regenerate `package-lock.json` if it drifted from `package.json`, producing artifacts that differ from what tests exercised.
- **`src/utils/api.ts`** — deduplicate concurrent OAuth token requests. With a cold/expired cache, two parallel API tool invocations each saw `cachedToken === null` and fired their own `fetch(/connect/token)`. The fix caches an `inFlightTokenRequest` promise so concurrent callers share one network call. New test in `tests/utils/api.spec.ts` fires five concurrent callers against a held-open fetch and asserts only one fetch is made.

Each commit is independent and easy to revert in isolation.

## Test plan

- [x] `npm test` — 486/486 pass (including the new dedupe test)
- [x] `npm run build` — clean
- [x] `npx eslint src/utils/api.ts tests/utils/api.spec.ts` — clean
- [x] `npx prettier --check` on changed files — clean
- [ ] Reviewer verifies Docker image still builds end-to-end via the build workflow
- [ ] Reviewer confirms the OAuth dedupe behavior matches their intent (the change is conservative: cache + in-flight promise, no other semantic changes)

## Notes

A separate companion issue will be filed describing some softer findings from the same audit (raw `bw` stderr forwarded to the LLM, env-var inheritance into `bw` subprocesses, schema UUID consistency) so the security team can decide on direction independently — those are not included here to keep this PR tight and reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)