### PR TITLE
[deps]: Track @bitwarden/cli in Dockerfile via Renovate and bump to 2026.4.1

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["(^|/)Dockerfile$"],
+      "managerFilePatterns": ["**/Dockerfile"],
       "matchStrings": ["@bitwarden/cli@(?<currentValue>[^\\s'\"]+)"],
       "depNameTemplate": "@bitwarden/cli",
       "datasourceTemplate": "npm",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>bitwarden/renovate-config"],
-  "enabledManagers": ["dockerfile", "github-actions", "npm"],
+  "enabledManagers": ["dockerfile", "github-actions", "npm", "custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile$"],
+      "matchStrings": ["@bitwarden/cli@(?<currentValue>[^\\s'\"]+)"],
+      "depNameTemplate": "@bitwarden/cli",
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "loose"
+    }
+  ],
   "packageRules": [
     {
       "groupName": "dockerfile minor",

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY package.json package-lock.json tsconfig.json ./
 
 RUN npm ci --ignore-scripts --omit-dev
-RUN npm install --ignore-scripts @bitwarden/cli@2025.7.0
+RUN npm install --ignore-scripts @bitwarden/cli@2026.4.1
 
 FROM dependencies AS builder
 


### PR DESCRIPTION
## 🎟️ Tracking

Ad-hoc maintenance — no Jira ticket. Follow-up to [#189](https://github.com/bitwarden/mcp-server/pull/189), which introduced the pinned `@bitwarden/cli` install in the Dockerfile.

## 📔 Objective

Two related changes:

1. **Renovate custom manager for the Dockerfile CLI pin.** The Dockerfile installs the Bitwarden CLI via `RUN npm install --ignore-scripts @bitwarden/cli@<version>`. Renovate's built-in `dockerfile` manager only tracks `FROM` lines, so this version pin was previously invisible to Renovate. Added a `custom.regex` manager scoped to `Dockerfile`, using the `npm` datasource and `loose` versioning (since `@bitwarden/cli` uses `YYYY.M.PATCH` calendar versioning, not strict semver). `custom.regex` is also added to `enabledManagers` since that list is set restrictively.

2. **Bump `@bitwarden/cli` from `2025.7.0` → `2026.4.1`.** The previous pin (`2025.7.0`) was not published to npm — the registry's `latest` is `2026.4.1`. This restores the pin to a real, current version.

Going forward, Renovate will open PRs for this dependency automatically as new versions ship.