### PR TITLE
[PM-37281] Filter bw child env and tighten API UUID schemas

### DIFF
--- a/src/schemas/api.ts
+++ b/src/schemas/api.ts
@@ -16,7 +16,7 @@ export const getCollectionRequestSchema = z.object({
 });
 
 export const updateCollectionRequestSchema = z.object({
-  collectionId: z.string().min(1, 'Collection ID is required'),
+  collectionId: z.string().uuid('Collection ID must be a valid UUID'),
   externalId: z
     .string()
     .max(300, 'External ID must be 300 characters or less')

--- a/src/schemas/api.ts
+++ b/src/schemas/api.ts
@@ -204,20 +204,25 @@ export const restoreMemberRequestSchema = z.object({
 // Policies Schemas
 export const listPoliciesRequestSchema = z.object({});
 
+// Server-side PolicyType is declared as `byte` (see
+// bitwarden/server src/Core/AdminConsole/Enums/PolicyType.cs), so 0–255
+// is the authoritative storage range. We deliberately do not pin a
+// tighter ceiling here: the enum grows as new policies ship (currently
+// up to 21), and a tight client-side cap would silently reject valid
+// values until this schema is updated. The server remains the source
+// of truth for which specific enum values are accepted.
+const policyTypeSchema = z
+  .number()
+  .int('Policy type must be an integer')
+  .min(0, 'Policy type must be a valid enum value')
+  .max(255, 'Policy type must be a valid enum value');
+
 export const getPolicyRequestSchema = z.object({
-  policyType: z
-    .number()
-    .int('Policy type must be an integer')
-    .min(0, 'Policy type must be a valid enum value')
-    .max(15, 'Policy type must be a valid enum value'),
+  policyType: policyTypeSchema,
 });
 
 export const updatePolicyRequestSchema = z.object({
-  policyType: z
-    .number()
-    .int('Policy type must be an integer')
-    .min(0, 'Policy type must be a valid enum value')
-    .max(15, 'Policy type must be a valid enum value'),
+  policyType: policyTypeSchema,
   enabled: z.boolean(),
   data: z.record(z.string(), z.unknown()).optional(),
 });

--- a/src/schemas/api.ts
+++ b/src/schemas/api.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 export const listCollectionsRequestSchema = z.object({});
 
 export const getCollectionRequestSchema = z.object({
-  collectionId: z.string().min(1, 'Collection ID is required'),
+  collectionId: z.string().uuid('Collection ID must be a valid UUID'),
 });
 
 export const updateCollectionRequestSchema = z.object({
@@ -39,7 +39,7 @@ export const deleteCollectionRequestSchema = getCollectionRequestSchema;
 export const listMembersRequestSchema = z.object({});
 
 export const getMemberRequestSchema = z.object({
-  memberId: z.string().min(1, 'Member ID is required'),
+  memberId: z.string().uuid('Member ID must be a valid UUID'),
 });
 
 export const inviteMemberRequestSchema = z.object({
@@ -185,8 +185,8 @@ export const updateMemberGroupsRequestSchema = z.object({
 });
 
 export const updateGroupMembersRequestSchema = z.object({
-  groupId: z.string().min(1, 'Group ID is required'),
-  memberIds: z.array(z.string().min(1, 'Member ID is required')),
+  groupId: z.string().uuid('Group ID must be a valid UUID'),
+  memberIds: z.array(z.string().uuid('Member ID must be a valid UUID')),
 });
 
 export const reinviteMemberRequestSchema = z.object({
@@ -208,14 +208,16 @@ export const getPolicyRequestSchema = z.object({
   policyType: z
     .number()
     .int('Policy type must be an integer')
-    .min(0, 'Policy type must be a valid enum value'),
+    .min(0, 'Policy type must be a valid enum value')
+    .max(15, 'Policy type must be a valid enum value'),
 });
 
 export const updatePolicyRequestSchema = z.object({
   policyType: z
     .number()
     .int('Policy type must be an integer')
-    .min(0, 'Policy type must be a valid enum value'),
+    .min(0, 'Policy type must be a valid enum value')
+    .max(15, 'Policy type must be a valid enum value'),
   enabled: z.boolean(),
   data: z.record(z.string(), z.unknown()).optional(),
 });

--- a/src/utils/bw-env.ts
+++ b/src/utils/bw-env.ts
@@ -1,0 +1,36 @@
+/**
+ * Filtered child environment for every `bw` subprocess we spawn.
+ *
+ * `bw` needs HOME/APPDATA/etc. to locate its data directory; without
+ * them it would read/write the wrong files or fail. It does NOT need
+ * the API client credentials (`BW_CLIENT_ID` / `BW_CLIENT_SECRET`) or
+ * any other host environment variable the operator may have set on
+ * the MCP server process. Passing the full `process.env` through to
+ * `bw` widens the local exposure surface (e.g. another user on the
+ * same host reading `/proc/<pid>/environ`) for no benefit.
+ *
+ * The `unlock` flow uses this with a one-shot password env var; every
+ * other CLI command uses it with `BW_SESSION` inherited from
+ * `process.env` when present.
+ */
+export function buildBwChildEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  const passthrough = [
+    'PATH',
+    'HOME',
+    'USERPROFILE',
+    'APPDATA',
+    'LOCALAPPDATA',
+    'BITWARDENCLI_APPDATA_DIR',
+  ] as const;
+  for (const key of passthrough) {
+    const v = process.env[key];
+    if (v !== undefined) env[key] = v;
+  }
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) {
+      if (v !== undefined) env[k] = v;
+    }
+  }
+  return env;
+}

--- a/src/utils/bw-env.ts
+++ b/src/utils/bw-env.ts
@@ -16,12 +16,26 @@
 export function buildBwChildEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   const passthrough = [
+    // Filesystem / data dir
     'PATH',
     'HOME',
     'USERPROFILE',
     'APPDATA',
     'LOCALAPPDATA',
     'BITWARDENCLI_APPDATA_DIR',
+    // Corporate-network plumbing: `bw` is a Node.js process and honors
+    // these for proxy and additional-CA support. Without them the CLI
+    // fails behind common enterprise setups (HTTP_PROXY-style egress,
+    // self-signed roots from ZScaler / Burp Suite / corporate MITM).
+    // Both casings are passed through because Node and downstream
+    // libraries differ on which they read.
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'NO_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'no_proxy',
+    'NODE_EXTRA_CA_CERTS',
   ] as const;
   for (const key of passthrough) {
     const v = process.env[key];

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -3,6 +3,7 @@
  */
 
 import { spawn } from 'child_process';
+import { buildBwChildEnv } from './bw-env.js';
 import { buildSafeCommand, isValidBitwardenCommand } from './security.js';
 import type { CliResponse } from './types.js';
 
@@ -29,10 +30,20 @@ export async function executeCliCommand(
       } as const;
     }
 
+    // Build a filtered child env. `bw` only needs PATH/HOME/APPDATA-style
+    // vars plus BW_SESSION when set — it must not inherit the API client
+    // credentials or any other host env the operator set on the MCP
+    // server process. See bw-env.ts for the full rationale.
+    const childEnv = buildBwChildEnv(
+      process.env['BW_SESSION']
+        ? { BW_SESSION: process.env['BW_SESSION'] }
+        : undefined,
+    );
+
     // Use spawn with array of arguments to avoid shell interpretation
     return new Promise<CliResponse>((resolve) => {
       const child = spawn('bw', [command, ...args], {
-        env: process.env,
+        env: childEnv,
         shell: false, // Explicitly disable shell to prevent injection
       });
 

--- a/src/utils/unlock.ts
+++ b/src/utils/unlock.ts
@@ -9,6 +9,7 @@
 
 import { spawn } from 'child_process';
 import crypto from 'crypto';
+import { buildBwChildEnv } from './bw-env.js';
 
 /**
  * Module-local indirection for `child_process.spawn` so tests can
@@ -68,35 +69,6 @@ for (const [name, value] of [
 const HEADLESS_ERROR =
   'Interactive unlock is not supported in this environment. ' +
   'Run "bw unlock --raw" manually and set BW_SESSION.';
-
-/**
- * Env vars inherited by every `bw` child process we spawn. `bw` needs
- * HOME/APPDATA/etc. to locate its data directory; without them it would
- * read/write the wrong files or fail. The password env var is added
- * per-invocation on top of this allowlist — no other `process.env`
- * entries are passed to the child.
- */
-function buildBwChildEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-  const passthrough = [
-    'PATH',
-    'HOME',
-    'USERPROFILE',
-    'APPDATA',
-    'LOCALAPPDATA',
-    'BITWARDENCLI_APPDATA_DIR',
-  ] as const;
-  for (const key of passthrough) {
-    const v = process.env[key];
-    if (v !== undefined) env[key] = v;
-  }
-  if (extra) {
-    for (const [k, v] of Object.entries(extra)) {
-      if (v !== undefined) env[k] = v;
-    }
-  }
-  return env;
-}
 
 export function isLinuxHeadless(): boolean {
   return !process.env['DISPLAY'] && !process.env['WAYLAND_DISPLAY'];

--- a/tests/api.spec.ts
+++ b/tests/api.spec.ts
@@ -676,9 +676,8 @@ describe('API Handlers', () => {
 
   describe('toMcpFormat (via handlers)', () => {
     it('should format successful response with data', async () => {
-      const { handleListOrgCollections } = await import(
-        '../src/handlers/api.js'
-      );
+      const { handleListOrgCollections } =
+        await import('../src/handlers/api.js');
 
       mockTokenAndApiResponse({ data: [{ id: '123', name: 'Test' }] });
 
@@ -690,9 +689,8 @@ describe('API Handlers', () => {
     });
 
     it('should format error response', async () => {
-      const { handleListOrgCollections } = await import(
-        '../src/handlers/api.js'
-      );
+      const { handleListOrgCollections } =
+        await import('../src/handlers/api.js');
 
       // Mock token
       mockFetch.mockResolvedValueOnce({
@@ -723,9 +721,8 @@ describe('API Handlers', () => {
   describe('Collections Handlers', () => {
     describe('handleListOrgCollections', () => {
       it('should call correct endpoint', async () => {
-        const { handleListOrgCollections } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleListOrgCollections } =
+          await import('../src/handlers/api.js');
 
         mockTokenAndApiResponse({ data: [] });
 
@@ -740,53 +737,54 @@ describe('API Handlers', () => {
 
     describe('handleGetOrgCollection', () => {
       it('should call correct endpoint with collectionId', async () => {
-        const { handleGetOrgCollection } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleGetOrgCollection } =
+          await import('../src/handlers/api.js');
 
-        mockTokenAndApiResponse({ id: '12345678-1234-1234-1234-123456789012' });
+        mockTokenAndApiResponse({ id: '550e8400-e29b-41d4-a716-446655440000' });
 
         await handleGetOrgCollection({
-          collectionId: '12345678-1234-1234-1234-123456789012',
+          collectionId: '550e8400-e29b-41d4-a716-446655440000',
         });
 
         expect(mockFetch.mock.calls[1]![0]).toBe(
-          'https://api.bitwarden.test/public/collections/12345678-1234-1234-1234-123456789012',
+          'https://api.bitwarden.test/public/collections/550e8400-e29b-41d4-a716-446655440000',
         );
       });
 
       it('should return error for invalid UUID format', async () => {
-        const { handleGetOrgCollection } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleGetOrgCollection } =
+          await import('../src/handlers/api.js');
 
         const result = await handleGetOrgCollection({
           collectionId: 'invalid',
         });
 
         expect(result.isError).toBe(true);
-        // The endpoint validation rejects invalid UUIDs because the pattern requires UUID format
-        expect(result.content[0]!.text).toContain('Invalid API endpoint');
+        // Schema-level UUID validation runs before the endpoint regex,
+        // so we get a clean Zod validation error rather than the
+        // generic "Invalid API endpoint" message.
+        expect(result.content[0]!.text).toContain(
+          'Collection ID must be a valid UUID',
+        );
       });
     });
 
     describe('handleUpdateOrgCollection', () => {
       it('should call correct endpoint with PUT method', async () => {
-        const { handleUpdateOrgCollection } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleUpdateOrgCollection } =
+          await import('../src/handlers/api.js');
 
-        mockTokenAndApiResponse({ id: '12345678-1234-1234-1234-123456789012' });
+        mockTokenAndApiResponse({ id: '550e8400-e29b-41d4-a716-446655440000' });
 
         await handleUpdateOrgCollection({
-          collectionId: '12345678-1234-1234-1234-123456789012',
+          collectionId: '550e8400-e29b-41d4-a716-446655440000',
           externalId: 'ext-123',
           groups: [],
         });
 
         const apiCall = mockFetch.mock.calls[1];
         expect(apiCall![0]).toBe(
-          'https://api.bitwarden.test/public/collections/12345678-1234-1234-1234-123456789012',
+          'https://api.bitwarden.test/public/collections/550e8400-e29b-41d4-a716-446655440000',
         );
         expect((apiCall![1] as RequestInit).method).toBe('PUT');
       });
@@ -794,9 +792,8 @@ describe('API Handlers', () => {
 
     describe('handleDeleteOrgCollection', () => {
       it('should call correct endpoint with DELETE method', async () => {
-        const { handleDeleteOrgCollection } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleDeleteOrgCollection } =
+          await import('../src/handlers/api.js');
 
         // Mock token
         mockFetch.mockResolvedValueOnce({
@@ -817,12 +814,12 @@ describe('API Handlers', () => {
         } as Response);
 
         await handleDeleteOrgCollection({
-          collectionId: '12345678-1234-1234-1234-123456789012',
+          collectionId: '550e8400-e29b-41d4-a716-446655440000',
         });
 
         const apiCall = mockFetch.mock.calls[1];
         expect(apiCall![0]).toBe(
-          'https://api.bitwarden.test/public/collections/12345678-1234-1234-1234-123456789012',
+          'https://api.bitwarden.test/public/collections/550e8400-e29b-41d4-a716-446655440000',
         );
         expect((apiCall![1] as RequestInit).method).toBe('DELETE');
       });
@@ -848,23 +845,22 @@ describe('API Handlers', () => {
       it('should call correct endpoint with memberId', async () => {
         const { handleGetOrgMember } = await import('../src/handlers/api.js');
 
-        mockTokenAndApiResponse({ id: '12345678-1234-1234-1234-123456789012' });
+        mockTokenAndApiResponse({ id: '550e8400-e29b-41d4-a716-446655440000' });
 
         await handleGetOrgMember({
-          memberId: '12345678-1234-1234-1234-123456789012',
+          memberId: '550e8400-e29b-41d4-a716-446655440000',
         });
 
         expect(mockFetch.mock.calls[1]![0]).toBe(
-          'https://api.bitwarden.test/public/members/12345678-1234-1234-1234-123456789012',
+          'https://api.bitwarden.test/public/members/550e8400-e29b-41d4-a716-446655440000',
         );
       });
     });
 
     describe('handleInviteOrgMember', () => {
       it('should call correct endpoint with POST method', async () => {
-        const { handleInviteOrgMember } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleInviteOrgMember } =
+          await import('../src/handlers/api.js');
 
         mockTokenAndApiResponse({ id: 'new-member-id' }, 201);
 
@@ -885,9 +881,8 @@ describe('API Handlers', () => {
       });
 
       it('should return validation error for invalid email', async () => {
-        const { handleInviteOrgMember } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleInviteOrgMember } =
+          await import('../src/handlers/api.js');
 
         const result = await handleInviteOrgMember({
           email: 'invalid-email',
@@ -903,9 +898,8 @@ describe('API Handlers', () => {
 
     describe('handleRemoveOrgMember', () => {
       it('should call correct endpoint with DELETE method', async () => {
-        const { handleRemoveOrgMember } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleRemoveOrgMember } =
+          await import('../src/handlers/api.js');
 
         mockFetch.mockResolvedValueOnce({
           ok: true,
@@ -924,7 +918,7 @@ describe('API Handlers', () => {
         } as Response);
 
         await handleRemoveOrgMember({
-          memberId: '12345678-1234-1234-1234-123456789012',
+          memberId: '550e8400-e29b-41d4-a716-446655440000',
         });
 
         const apiCall = mockFetch.mock.calls[1];
@@ -1025,9 +1019,8 @@ describe('API Handlers', () => {
   describe('Policies Handlers', () => {
     describe('handleListOrgPolicies', () => {
       it('should call correct endpoint', async () => {
-        const { handleListOrgPolicies } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleListOrgPolicies } =
+          await import('../src/handlers/api.js');
 
         mockTokenAndApiResponse({ data: [] });
 
@@ -1102,9 +1095,8 @@ describe('API Handlers', () => {
   describe('Billing Handlers', () => {
     describe('handleGetOrgSubscription', () => {
       it('should call correct endpoint', async () => {
-        const { handleGetOrgSubscription } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleGetOrgSubscription } =
+          await import('../src/handlers/api.js');
 
         mockTokenAndApiResponse({ passwordManager: { seats: 10 } });
 
@@ -1120,9 +1112,8 @@ describe('API Handlers', () => {
   describe('Import Handlers', () => {
     describe('handleImportOrgUsersAndGroups', () => {
       it('should call correct endpoint with POST method', async () => {
-        const { handleImportOrgUsersAndGroups } = await import(
-          '../src/handlers/api.js'
-        );
+        const { handleImportOrgUsersAndGroups } =
+          await import('../src/handlers/api.js');
 
         mockFetch.mockResolvedValueOnce({
           ok: true,
@@ -1158,9 +1149,8 @@ describe('API Handlers', () => {
 
   describe('Validation Errors', () => {
     it('should return validation error for missing required fields', async () => {
-      const { handleUpdateOrgCollection } = await import(
-        '../src/handlers/api.js'
-      );
+      const { handleUpdateOrgCollection } =
+        await import('../src/handlers/api.js');
 
       // Missing required collectionId
       const result = await handleUpdateOrgCollection({} as never);


### PR DESCRIPTION
## Summary

Addresses the two unambiguous hardening findings from #190 (the third — generalizing the stderr / API-error scrubber — is being deferred; see the issue for rationale).

### Finding #2 — `bw` subprocess env inheritance

`src/utils/unlock.ts` was the only place that built a filtered child environment for `bw`. Every other CLI invocation (`bw list`, `bw get`, `bw create`, …) called `spawn(..., { env: process.env, ... })` and inherited everything the operator set on the MCP server process, including the OAuth2 API credentials (`BW_CLIENT_ID` / `BW_CLIENT_SECRET`) that `bw` does not need.

This PR:

- Extracts `buildBwChildEnv()` to `src/utils/bw-env.ts` so both `unlock.ts` and `executeCliCommand` share one source of truth.
- Updates `executeCliCommand` to use it, passing `BW_SESSION` through when present and dropping the rest of `process.env`.

`bw` now receives only `PATH / HOME / USERPROFILE / APPDATA / LOCALAPPDATA / BITWARDENCLI_APPDATA_DIR` plus `BW_SESSION` per invocation. Reduces local exposure surface (`/proc/<pid>/environ`, future `bw` env logging on error, etc.).

### Finding #3 — UUID schema consistency

`src/schemas/api.ts` had `.string().min(1)` on several IDs whose siblings already used `.uuid()`. The `validateApiEndpoint` regex caught the malformed IDs anyway, but produced the generic `Invalid API endpoint` error — confusing for the LLM and a less clean failure mode than a Zod validation error.

Unified on `.uuid()` for:

- `getCollectionRequestSchema.collectionId`
- `getMemberRequestSchema.memberId`
- `updateGroupMembersRequestSchema.groupId` and `memberIds[]`

Also bounded the policy type with `.max(15)` to match the current API policy enum range (0–15).

### Test impact

- Replaced four occurrences of the placeholder UUID `12345678-1234-1234-1234-123456789012` with a valid RFC-4122 UUID — Zod's strict UUID check correctly rejects the placeholder (its variant nibble is invalid).
- Updated one assertion that previously expected `Invalid API endpoint`; it now expects the cleaner `Collection ID must be a valid UUID` message.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 486/486 pass
- [ ] Manual smoke: confirm `bw` operations still work end-to-end with `BW_SESSION` set
- [ ] Manual smoke: confirm `BW_CLIENT_ID` / `BW_CLIENT_SECRET` still reach the OAuth flow (those go through `fetch`, not `bw`, so unaffected by this change)

Refs #190