### PR TITLE
fix: Resolve symlinks before BW_ALLOWED_DIRECTORIES check

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -169,7 +169,7 @@ The `validateFilePath()` function provides defense-in-depth protection against p
 5. **Unicode normalization** - Converts fullwidth characters and variants to canonical form (NFC)
 6. **Pattern matching** - Detects traversal sequences (../, ..\, etc.)
 7. **Unicode lookalike detection** - Blocks alternative slash characters (U+2215, U+FF0F, etc.)
-8. **Path canonicalization** - Resolves to absolute paths
+8. **Path canonicalization** - Resolves to absolute paths and follows symlinks via `fs.realpathSync.native()`. Both the candidate path and every `BW_ALLOWED_DIRECTORIES` entry are canonicalized before the prefix check, so a symlink inside the allowlist cannot smuggle in a file whose real path is outside it. Non-existent path segments fall back to lexical resolution against the longest existing ancestor.
 9. **Allowlist validation** - Only permits files within `BW_ALLOWED_DIRECTORIES`
 
 **Environment Configuration**:
@@ -195,6 +195,7 @@ set BW_ALLOWED_DIRECTORIES=C:/Users/YourName/Documents,C:/Temp/Bitwarden
 - UNC path variants (`\localhost\c$`)
 - Overlong UTF-8 encoding
 - Mixed encoding techniques
+- Symlink-based escapes (a symlink inside the allowlist whose target is outside it)
 
 ### Security Rules
 

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -2,7 +2,29 @@
  * Security utilities for input sanitization and validation
  */
 
+import fs from 'fs';
 import path from 'path';
+
+/**
+ * Canonicalize a filesystem path by resolving symbolic links.
+ *
+ * Uses fs.realpathSync.native() when the path exists. If the path does not
+ * exist (e.g. a not-yet-created download target), we recursively canonicalize
+ * the longest existing ancestor and re-attach the missing tail. This ensures
+ * a partially-existing path cannot smuggle in a symlinked ancestor that
+ * silently redirects outside the allowlist.
+ */
+function canonicalizePath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    const parent = path.dirname(filePath);
+    if (parent === filePath) {
+      return filePath;
+    }
+    return path.join(canonicalizePath(parent), path.basename(filePath));
+  }
+}
 
 /**
  * Sanitizes a string to prevent command injection by removing dangerous characters
@@ -194,7 +216,7 @@ export function sanitizeApiParameters(params: unknown): unknown {
  * Security measures:
  * - URL decoding (iterative to handle double encoding)
  * - Unicode normalization (NFC form)
- * - Path resolution to canonical form
+ * - Path resolution to canonical form (with symlink resolution via realpath)
  * - Allowlist-based directory validation
  * - Protection against all known bypass techniques
  *
@@ -283,8 +305,13 @@ export function validateFilePath(filePath: string): boolean {
       return false;
     }
 
-    // Step 8: Resolve to absolute canonical path
-    const resolvedPath = path.resolve(normalizedPath);
+    // Step 8: Resolve to absolute canonical path, including symlink resolution.
+    // Lexical resolution alone (path.resolve) only collapses ./ and ../; it does
+    // not follow symlinks. Without realpath, a symlink inside an allowed
+    // directory could target a file outside the allowlist and pass the prefix
+    // check below. canonicalizePath() resolves symlinks via realpath and falls
+    // back to lexical resolution for non-existent path segments.
+    const resolvedPath = canonicalizePath(path.resolve(normalizedPath));
 
     // Step 9: Get allowed directories from environment variable
     // Fail closed: if BW_ALLOWED_DIRECTORIES is unset, reject all file operations.
@@ -296,11 +323,14 @@ export function validateFilePath(filePath: string): boolean {
       return false;
     }
 
+    // Allowed directories are canonicalized too, so that a symlinked allow-list
+    // entry (e.g. /tmp on macOS → /private/tmp) compares consistently with
+    // candidates that have been canonicalized through the symlink.
     const allowedDirectories = allowedDirsEnv
       .split(',')
       .map((dir) => dir.trim())
       .filter((dir) => dir.length > 0)
-      .map((dir) => path.resolve(dir));
+      .map((dir) => canonicalizePath(path.resolve(dir)));
 
     if (allowedDirectories.length === 0) {
       return false;

--- a/tests/security.spec.ts
+++ b/tests/security.spec.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import {
   sanitizeInput,
   validateParameter,
@@ -773,6 +776,78 @@ describe('Security - Command Injection Protection', () => {
           const result = validateFilePath(path);
           expect(typeof result).toBe('boolean');
         });
+      });
+    });
+
+    describe('Symlink Resolution (VULN-585)', () => {
+      // Regression coverage for the lexical-prefix bypass: a symlink inside
+      // an allowed directory whose target lives outside the allowlist must
+      // be rejected once the candidate path is canonicalized.
+      const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bw-symlink-'));
+      const allowedDir = fs.realpathSync.native(
+        fs.mkdtempSync(path.join(tmpRoot, 'allowed-')),
+      );
+      const outsideDir = fs.realpathSync.native(
+        fs.mkdtempSync(path.join(tmpRoot, 'outside-')),
+      );
+      const outsideFile = path.join(outsideDir, 'secret.txt');
+      const insideFile = path.join(allowedDir, 'inside.txt');
+      const symlinkToOutsideFile = path.join(allowedDir, 'link-to-secret.txt');
+      const symlinkToOutsideDir = path.join(allowedDir, 'link-to-outside');
+
+      const originalEnv = process.env['BW_ALLOWED_DIRECTORIES'];
+
+      beforeAll(() => {
+        fs.writeFileSync(outsideFile, 'outside-allowlist-secret\n');
+        fs.writeFileSync(insideFile, 'inside-allowlist\n');
+        fs.symlinkSync(outsideFile, symlinkToOutsideFile);
+        fs.symlinkSync(outsideDir, symlinkToOutsideDir);
+      });
+
+      afterAll(() => {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+        if (originalEnv) {
+          process.env['BW_ALLOWED_DIRECTORIES'] = originalEnv;
+        } else {
+          delete process.env['BW_ALLOWED_DIRECTORIES'];
+        }
+      });
+
+      beforeEach(() => {
+        process.env['BW_ALLOWED_DIRECTORIES'] = allowedDir;
+      });
+
+      it('should reject a symlink inside the allowlist that targets a file outside', () => {
+        expect(validateFilePath(symlinkToOutsideFile)).toBe(false);
+      });
+
+      it('should reject a path that traverses through a symlinked directory to a file outside', () => {
+        const traversed = path.join(symlinkToOutsideDir, 'secret.txt');
+        expect(validateFilePath(traversed)).toBe(false);
+      });
+
+      it('should still accept a real file inside the allowlist', () => {
+        expect(validateFilePath(insideFile)).toBe(true);
+      });
+
+      it('should accept a not-yet-created file inside the allowlist', () => {
+        const newFile = path.join(allowedDir, 'does-not-exist-yet.txt');
+        expect(validateFilePath(newFile)).toBe(true);
+      });
+
+      it('should accept paths under an allowlist entry that is itself a symlink', () => {
+        // Configure the allowlist via a symlink pointing at the real allowed
+        // directory. After canonicalization both sides must resolve to the
+        // same real path so legitimate files are still accepted.
+        const symlinkedAllowEntry = path.join(tmpRoot, 'allow-link');
+        fs.symlinkSync(allowedDir, symlinkedAllowEntry);
+        try {
+          process.env['BW_ALLOWED_DIRECTORIES'] = symlinkedAllowEntry;
+          expect(validateFilePath(insideFile)).toBe(true);
+          expect(validateFilePath(symlinkToOutsideFile)).toBe(false);
+        } finally {
+          fs.unlinkSync(symlinkedAllowEntry);
+        }
       });
     });
   });


### PR DESCRIPTION
## 🎟️ Tracking

[VULN-585](https://bitwarden.atlassian.net/browse/VULN-585) — HackerOne report 3752757.

## 📔 Objective

`validateFilePath()` enforced the `BW_ALLOWED_DIRECTORIES` allowlist with a lexical prefix check (`path.resolve` + `startsWith`). It never canonicalized symbolic links, so a symlink inside an allowed directory could point to a file outside the allowlist; the check passed, and `bw send create --file` / `bw create attachment --file` followed the symlink at upload time. The realistic attack is a workspace allowlist (e.g. `BW_ALLOWED_DIRECTORIES=/Users/alice/project`) that contains an untrusted clone with a symlink to `~/.ssh/id_rsa` or another sensitive file.

This change:

- Adds a `canonicalizePath()` helper that calls `fs.realpathSync.native()` and falls back to lexical resolution for not-yet-existent path segments (so download-output targets still validate).
- Canonicalizes **both** the candidate path and every `BW_ALLOWED_DIRECTORIES` entry before the prefix comparison, so a symlinked allowlist entry (`/tmp` → `/private/tmp` on macOS) compares consistently against canonicalized candidates.
- Adds regression coverage in `tests/security.spec.ts` that creates real symlinks in a temp directory and asserts:
  - a symlink inside the allowlist whose target is outside is rejected (the reported PoC);
  - traversal through a symlinked directory to an outside file is rejected;
  - a real file inside the allowlist is still accepted;
  - a not-yet-created file inside the allowlist is still accepted (download case);
  - an allowlist entry that is itself a symlink resolves correctly on both sides of the check.
- Documents the symlink-resolution layer in `.claude/CLAUDE.md`.

Full suite: 9 suites, 491 tests pass (5 new).

[VULN-585]: https://bitwarden.atlassian.net/browse/VULN-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ