### PR TITLE
[PM-39304] fix: Render Windows unlock dialog via WinForms

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -59,7 +59,7 @@ because it must collect a master password without exposing it to the LLM.
   smuggled in as an argument.
 - **Out-of-band password collection** — `src/utils/unlock.ts` spawns a
   native OS password dialog (`osascript` on macOS, `zenity`/`kdialog` on
-  Linux, PowerShell `PromptForCredential` on Windows). Dialog prompt text
+  Linux, a PowerShell WinForms dialog on Windows). Dialog prompt text
   MUST remain a compile-time constant — no interpolation of dynamic
   values.
 - **Password never touches argv** — the password is handed to

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ The `unlock` tool lets your AI assistant prompt you for your master password wit
 - When called, the server launches a **native OS password dialog**:
   - **macOS**: `osascript` secure input dialog
   - **Linux**: `zenity --password` (falls back to `kdialog --password`)
-  - **Windows**: PowerShell `PromptForCredential` secure credential dialog
+  - **Windows**: PowerShell WinForms password dialog (masked input)
 - The password is passed to `bw unlock --raw` via the `--passwordenv` flag with a randomized one-shot environment variable. It never appears in process arguments, in the MCP protocol, or in the LLM's context.
 - The LLM only ever sees `"Vault unlocked successfully."` or a sanitized failure message (e.g. `"Invalid master password."`, `"Unlock cancelled."`).
 - If you are in a non-interactive environment, the tool will refuse to run and return a fixed message directing you to the `bw unlock --raw` manual flow.

--- a/src/utils/unlock.ts
+++ b/src/utils/unlock.ts
@@ -236,22 +236,64 @@ async function collectPasswordLinux(): Promise<PasswordResult> {
 }
 
 function collectPasswordWindows(): Promise<PasswordResult> {
-  // Literal PowerShell script. Encoded as UTF-16LE + Base64 and passed
-  // via -EncodedCommand so no quoting / escaping is possible across
-  // the shell boundary.
+  // Literal PowerShell script rendering a WinForms dialog. Encoded as
+  // UTF-16LE + Base64 and passed via -EncodedCommand so no quoting /
+  // escaping is possible across the shell boundary.
+  //
+  // We do NOT use `$host.UI.PromptForCredential`: under the console host
+  // it prompts inline on the console rather than as a GUI window, and a
+  // process the MCP host spawns has no attached console, so it returns
+  // $null and the flow reports a false "Unlock cancelled" — the dialog
+  // never appears. A WinForms form renders regardless of console state.
   const script = [
     `$ErrorActionPreference = 'Stop'`,
-    `$cred = $host.UI.PromptForCredential('${DIALOG_TITLE}', '${DIALOG_PROMPT}', 'bitwarden', '')`,
-    `if (-not $cred) { exit 1 }`,
-    `$bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($cred.Password)`,
-    `try { [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr) }`,
-    `finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }`,
+    `Add-Type -AssemblyName System.Windows.Forms`,
+    `Add-Type -AssemblyName System.Drawing`,
+    `$form = New-Object System.Windows.Forms.Form`,
+    `$form.Text = '${DIALOG_TITLE}'`,
+    `$form.TopMost = $true`,
+    `$form.StartPosition = 'CenterScreen'`,
+    `$form.FormBorderStyle = 'FixedDialog'`,
+    `$form.MinimizeBox = $false`,
+    `$form.MaximizeBox = $false`,
+    `$form.ClientSize = New-Object System.Drawing.Size(360, 130)`,
+    `$label = New-Object System.Windows.Forms.Label`,
+    `$label.Text = '${DIALOG_PROMPT}'`,
+    `$label.AutoSize = $true`,
+    `$label.Location = New-Object System.Drawing.Point(12, 15)`,
+    `$textBox = New-Object System.Windows.Forms.TextBox`,
+    `$textBox.UseSystemPasswordChar = $true`,
+    `$textBox.Location = New-Object System.Drawing.Point(12, 45)`,
+    `$textBox.Size = New-Object System.Drawing.Size(336, 20)`,
+    `$ok = New-Object System.Windows.Forms.Button`,
+    `$ok.Text = 'Unlock'`,
+    `$ok.DialogResult = [System.Windows.Forms.DialogResult]::OK`,
+    `$ok.Location = New-Object System.Drawing.Point(192, 90)`,
+    `$cancel = New-Object System.Windows.Forms.Button`,
+    `$cancel.Text = 'Cancel'`,
+    `$cancel.DialogResult = [System.Windows.Forms.DialogResult]::Cancel`,
+    `$cancel.Location = New-Object System.Drawing.Point(273, 90)`,
+    `$form.Controls.Add($label)`,
+    `$form.Controls.Add($textBox)`,
+    `$form.Controls.Add($ok)`,
+    `$form.Controls.Add($cancel)`,
+    `$form.AcceptButton = $ok`,
+    `$form.CancelButton = $cancel`,
+    `$form.Add_Shown({ $form.Activate(); $textBox.Focus() })`,
+    `if ($form.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) { exit 1 }`,
+    `if ([string]::IsNullOrEmpty($textBox.Text)) { exit 1 }`,
+    // Emit UTF-8 without a BOM so a non-ASCII master password round-trips
+    // through the parent's default utf8 stdout decoding intact.
+    `[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false`,
+    `[Console]::Out.Write($textBox.Text)`,
   ].join('; ');
   const encoded = Buffer.from(script, 'utf16le').toString('base64');
+  // -Sta forces a single-threaded apartment, required for WinForms.
   return spawnDialog('powershell.exe', [
     '-NoProfile',
     '-ExecutionPolicy',
     'Bypass',
+    '-Sta',
     '-EncodedCommand',
     encoded,
   ]);

--- a/tests/unlock.spec.ts
+++ b/tests/unlock.spec.ts
@@ -809,10 +809,21 @@ describe('unlock flow (spawn-injected)', () => {
       const psArgs = psCall?.[1] as string[];
       expect(psArgs).toContain('-NoProfile');
       expect(psArgs).toContain('-EncodedCommand');
+      // WinForms requires a single-threaded apartment.
+      expect(psArgs).toContain('-Sta');
       // The encoded command must be base64 of the UTF-16LE script, not
       // plaintext — verify it doesn't contain the prompt in UTF-8.
       const encoded = psArgs[psArgs.indexOf('-EncodedCommand') + 1] as string;
       expect(encoded).not.toContain('Enter your Bitwarden');
+
+      // Decoding as UTF-16LE recovers the script: it must build a
+      // WinForms dialog (which renders without a console) and must NOT
+      // fall back to PromptForCredential (which does not).
+      const script = Buffer.from(encoded, 'base64').toString('utf16le');
+      expect(script).toContain('System.Windows.Forms.Form');
+      expect(script).toContain('ShowDialog');
+      expect(script).toContain('Enter your Bitwarden master password');
+      expect(script).not.toContain('PromptForCredential');
     });
 
     it('Unsupported platform: returns the fixed headless error', async () => {


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #206 (PM-39304). This is the second of the two bugs in that report; #209 fixed the first.

## 📔 Objective

Once the `spawn bw ENOENT` bug is fixed (#209), the Windows unlock flow is still unreachable. `collectPasswordWindows` builds a PowerShell script that calls `$host.UI.PromptForCredential`. Under the console host, that prompts inline on the console instead of opening a GUI window. A process the MCP host spawns (Claude Desktop, for example) has no attached console, so the call returns `$null`, the script exits non-zero, and the tool reports a false "Unlock cancelled". No dialog ever appears.

This PR replaces `PromptForCredential` with a WinForms password dialog launched with `-Sta`. WinForms renders regardless of console state, which brings Windows in line with the macOS `osascript` path that already pops a real GUI. The form uses a masked textbox and an Unlock/Cancel button pair, and it writes the entered password to stdout as UTF-8 without a BOM so a non-ASCII password round-trips through the parent's stdout decoding.

The unlock security invariants are unchanged:

- `DIALOG_TITLE` and `DIALOG_PROMPT` are still compile-time constants, so the module-load guard that rejects quote, escape, and dollar characters still covers every value interpolated into the script.
- The password is written to stdout and read out-of-band. It never touches argv, the MCP protocol, or the LLM context.
- Stderr is still scrubbed, the attempt is still serialized and rate-limited, and the already-unlocked short-circuit still runs first.

### Testing

- The Windows dialog test now asserts the generated script builds a WinForms form and calls `ShowDialog`, that `-Sta` is passed, and that `PromptForCredential` is gone.
- Full suite passes (502 tests), including the complete unlock suite.
- Updated the README and the unlock section of `.claude/CLAUDE.md`, both of which described the old `PromptForCredential` dialog.

One caveat: I can't exercise the real dialog from here (no Windows host), so the tests cover the generated script and argv rather than a live render.
