### PR TITLE
Bump version to 2026.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitwarden/mcp-server",
-  "version": "2026.5.1",
+  "version": "2026.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitwarden/mcp-server",
-      "version": "2026.5.1",
+      "version": "2026.7.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@bitwarden/mcp-server",
-  "version": "2026.5.1",
+  "version": "2026.7.0",
   "description": "Bitwarden MCP Server",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ async function runServer(): Promise<void> {
   const server = new Server(
     {
       name: 'Bitwarden MCP Server',
-      version: '2026.5.1',
+      version: '2026.7.0',
     },
     {
       capabilities: {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -110,7 +110,7 @@ export async function buildSafeApiRequest(
     headers: {
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
-      'User-Agent': 'Bitwarden-MCP-Server/2026.5.1',
+      'User-Agent': 'Bitwarden-MCP-Server/2026.7.0',
     },
   };
 

--- a/tests/utils/api.spec.ts
+++ b/tests/utils/api.spec.ts
@@ -194,7 +194,7 @@ describe('API Utilities', () => {
         headers: {
           Authorization: 'Bearer auth-token',
           'Content-Type': 'application/json',
-          'User-Agent': 'Bitwarden-MCP-Server/2026.5.1',
+          'User-Agent': 'Bitwarden-MCP-Server/2026.7.0',
         },
       });
     });


### PR DESCRIPTION
## 🎟️ Tracking

Routine version bump ahead of release.

## 📔 Objective

Bump the server version from 2026.5.1 to 2026.7.0 across the five files that carry it: package.json, package-lock.json, src/index.ts (MCP server version), src/utils/api.ts (User-Agent), and the matching tests/utils/api.spec.ts assertion. Same set of files as past bumps (#203, #192).