### PR TITLE
[AI-28] chore: Set team-ai-sme as default CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,15 +5,10 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default file owners
-* @bitwarden/dept-architecture
+* @bitwarden/team-ai-sme
 
 # Docker-related files
 **/Dockerfile @bitwarden/team-appsec @bitwarden/dept-bre
 **/*.dockerignore @bitwarden/team-appsec @bitwarden/dept-bre
 **/entrypoint.sh @bitwarden/team-appsec @bitwarden/dept-bre
 **/docker-compose.yml @bitwarden/team-appsec @bitwarden/dept-bre
-
-# Claude related files
-.claude/ @bitwarden/team-ai-sme
-.github/workflows/respond.yml @bitwarden/team-ai-sme
-.github/workflows/review-code.yml @bitwarden/team-ai-sme


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/AI-28

## 📔 Objective

Make `@bitwarden/team-ai-sme` the default `CODEOWNERS` for this repo (replacing `@bitwarden/dept-architecture`), and remove the now-redundant Claude-specific entries since they duplicated the same ownership as the new default.