### PR TITLE
fix: resolve lint errors in test setup and ignore coverage output

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -2,7 +2,6 @@ process.env.BW_SESSION = 'session';
 
 // Set up default allowed directories for file path validation tests
 // Include common test paths used across test files
-const path = require('path');
 const isWindows = process.platform === 'win32';
 const platformDirs = isWindows
   ? 'C:/Users,C:/home/user,C:/path/to,C:/tmp,D:/Backup'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,6 @@ export default defineConfig([
     files: ['**/*.ts'],
     languageOptions: { globals: globals.browser },
   },
-  globalIgnores(['dist/']),
+  globalIgnores(['dist/', 'coverage/']),
   tseslint.configs.recommended,
 ]);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,15 @@ export default defineConfig([
     files: ['**/*.ts'],
     languageOptions: { globals: globals.browser },
   },
-  globalIgnores(['dist/', 'coverage/']),
+  // Nested git worktrees are separate checkouts with their own sources, build
+  // output and coverage; linting them from the parent reports duplicate files.
+  // Covers both common locations: .worktrees/ (git-worktree.nvim) and
+  // .claude/worktrees/ (Claude Code).
+  globalIgnores([
+    '**/dist/',
+    '**/coverage/',
+    '.worktrees/',
+    '.claude/worktrees/',
+  ]),
   tseslint.configs.recommended,
 ]);


### PR DESCRIPTION
## Objective

`npm run lint` currently fails on `main`. This fixes it.

```
.jest/setEnvVars.js
  5:7   error  'path' is assigned a value but never used  @typescript-eslint/no-unused-vars
  5:14  error  A `require()` style import is forbidden    @typescript-eslint/no-require-imports
```

## Changes

**1. `.jest/setEnvVars.js` — remove the dead `require('path')`**

`path` was required but never referenced; the following lines use only `process.platform` and `process.cwd()`. The usage was removed in 95d3242 (`[VULN-305] extend file validation`) but the require was left behind. Deleting the single line clears both errors, since it was the file's only `require()`.

**2. `eslint.config.js` — add `coverage/` to `globalIgnores`**

Only `dist/` was ignored. Running `npm test` writes Istanbul reports into `coverage/`, so a subsequent `npm run lint` linted generated files and emitted unused-eslint-disable warnings:

```
coverage/block-navigation.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)
coverage/lcov-report/block-navigation.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)
```

## Why this rotted on `main`

Nothing enforces eslint on `.js` files:

- There is no lint job in `.github/workflows/` — CI never runs `npm run lint`.
- `lint-staged` scopes eslint to `*.ts` only (`package.json`), so a `.js` file is never linted pre-commit. The commit for this PR shows it directly: `*.ts — 0 files [SKIPPED]`.

Worth considering as a follow-up (deliberately **not** included here, since adding a required check is a policy decision): add `npm run lint` to CI, and/or widen the `lint-staged` eslint glob to `*.{ts,js}`. Without one of those, this class of error can silently return.

## Testing

- `npm run lint` → exit 0 (previously exit 1)
- `npm test` → exit 0, 502/502 passing
- Verified with `coverage/` present on disk, so the new ignore is actually exercised
- No source or test behavior changed; `setEnvVars.js` still sets `BW_SESSION` and `BW_ALLOWED_DIRECTORIES` identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VULN-305]: https://bitwarden.atlassian.net/browse/VULN-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ