### PR TITLE
chore: upgrade docker image to debian 13, fix lint error

### DIFF
--- a/.jest/setEnvVars.js
+++ b/.jest/setEnvVars.js
@@ -2,7 +2,6 @@ process.env.BW_SESSION = 'session';
 
 // Set up default allowed directories for file path validation tests
 // Include common test paths used across test files
-const path = require('path');
 const isWindows = process.platform === 'win32';
 const platformDirs = isWindows
   ? 'C:/Users,C:/home/user,C:/path/to,C:/tmp,D:/Backup'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 
 RUN npm run build
 
-FROM gcr.io/distroless/nodejs24-debian12:nonroot AS release
+FROM gcr.io/distroless/nodejs24-debian13:nonroot AS release
 
 WORKDIR /app
 USER nonroot


### PR DESCRIPTION
## 📔 Objective

Updating the Docker image to Debian 13 since Debian 12 is End of Life (EOL) July 11th 2026.

Fixed ESLint errors.

